### PR TITLE
Fix SKILL.md frontmatter: move version to metadata

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: imaging-data-commons
-version: 1.0.0
 description: Query and download public cancer imaging data from NCI Imaging Data Commons using idc-index. Use for accessing large-scale radiology (CT, MR, PET) and pathology datasets for AI training or research. No authentication required. Query by metadata, visualize in browser, check licenses.
 license: This skill is provided under the MIT License. IDC data itself has individual licensing (mostly CC-BY, some CC-NC) that must be respected when using the data.
 metadata:
+    version: 1.0.0
     skill-author: Andrey Fedorov, @fedorov
     idc-index: "0.11.7"
     repository: https://github.com/ImagingDataCommons/idc-claude-skill


### PR DESCRIPTION
The version key in the SKILL.md YAML frontmatter is a top-level property, which causes an upload error in Claude's skill uploader:

unexpected key in SKILL.md frontmatter: properties must be in ('name', 'description', 'license', 'allowed-tools', 'compatibility', 'metadata')

This PR moves version under the metadata block, which accepts arbitrary keys.