### PR TITLE
Add update notifications and rename repo references (v1.6.5)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,8 @@ jobs:
         run: |
           zip -r imaging-data-commons-${{ steps.version.outputs.version }}.zip \
             SKILL.md \
-            references/
+            references/ \
+            scripts/
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3

--- a/.github/workflows/test-snippets.yml
+++ b/.github/workflows/test-snippets.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ~/.idc
-          key: idc-index-0.11.14
+          key: idc-index-0.12.3
 
       - name: Install test dependencies
         run: pip install -r tests/requirements-test.txt

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ uv.lock
 main.py
 
 __pycache__/
+
+# Locally built release packages
+*.zip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to the IDC Claude Skill are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.6.5] - 2026-06-17
+
+### Added
+
+- `scripts/check_version.py` (run first): installs the pinned author-vetted `idc-index` minimum, then prints best-effort, notify-only notices when a newer `idc-index` (PyPI) or skill release (GitHub) is available — never auto-installs newer releases, silently skipped offline
+- "Keeping the Skill Up to Date" section in `USAGE.md` (release notifications, per-surface update steps, fresh-conversation reminder); linked from README
+
+### Changed
+
+- Replaced the inline startup version-check in `SKILL.md` with a prominent pointer to `scripts/check_version.py`, keeping the code out of the model's context
+- Renamed repository references `idc-claude-skill` → `imaging-data-commons-skill` across `SKILL.md`, `README.md`, `USAGE.md`
+- Pointed `tests/test_snippets.py` at the new script and added a guard that its `MIN_VERSION`/`SKILL_VERSION` match the SKILL.md frontmatter
+
+### Fixed
+
+- Standardized the required `idc-index` on `0.12.3` (was `0.12.2` in the version-check vs `0.12.3` in frontmatter) and switched to numeric, not string, version comparison
+
 ## [1.6.4] - 2026-05-22
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Once the skill is loaded, you can ask questions like:
 
 ## Reporting Issues
 
-If the skill provides incorrect or incomplete answers, please [open an issue](https://github.com/ImagingDataCommons/idc-claude-skill/issues/new/choose) using our issue template.
+If the skill provides incorrect or incomplete answers, please [open an issue](https://github.com/ImagingDataCommons/imaging-data-commons-skill/issues/new/choose) using our issue template.
 
 ## Setup Instructions
 
@@ -33,7 +33,7 @@ This skill follows [Semantic Versioning](https://semver.org/).
 
 - **Requires:** [idc-index](https://github.com/ImagingDataCommons/idc-index)
 
-See [CHANGELOG.md](CHANGELOG.md) for version history and [Releases](https://github.com/ImagingDataCommons/idc-claude-skill/releases) for downloads.
+See [CHANGELOG.md](CHANGELOG.md) for version history and [Releases](https://github.com/ImagingDataCommons/imaging-data-commons-skill/releases) for downloads. For how to stay current with new releases and IDC data versions, see [Keeping the Skill Up to Date](USAGE.md#keeping-the-skill-up-to-date).
 
 ## Credits
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -3,11 +3,11 @@ name: imaging-data-commons
 description: Query and download public cancer imaging data from NCI Imaging Data Commons using idc-index. Invoke for any question about IDC collections, cancer imaging datasets, DICOM data access, radiology (CT, MR, PET) or pathology AI training sets, metadata queries, visualization, or license checks — even when the user doesn't explicitly mention "IDC". No authentication required.
 license: This skill is provided under the MIT License. IDC data itself has individual licensing (mostly CC-BY, some CC-NC) that must be respected when using the data.
 metadata:
-    version: 1.6.4
+    version: 1.6.5
     skill-author: Andrey Fedorov, @fedorov
     idc-index: "0.12.3"
     idc-data-version: "v24"
-    repository: https://github.com/ImagingDataCommons/idc-claude-skill
+    repository: https://github.com/ImagingDataCommons/imaging-data-commons-skill
 ---
 
 # Imaging Data Commons
@@ -22,22 +22,16 @@ Use the `idc-index` Python package to query and download public cancer imaging d
 
 **Primary tool:** `idc-index` ([GitHub](https://github.com/imagingdatacommons/idc-index))
 
-**CRITICAL - Check package version and upgrade if needed (run this FIRST):**
+**CRITICAL - run this FIRST**, before any IDC query:
 
-```python
-import idc_index
-
-REQUIRED_VERSION = "0.12.2"  # Must match metadata.idc-index in this file
-installed = idc_index.__version__
-
-if installed < REQUIRED_VERSION:
-    print(f"Upgrading idc-index from {installed} to {REQUIRED_VERSION}...")
-    import subprocess
-    subprocess.run(["pip3", "install", "--upgrade", "--break-system-packages", f"idc-index=={REQUIRED_VERSION}"], check=True)
-    print("Upgrade complete. Restart Python to use new version.")
-else:
-    print(f"idc-index {installed} meets requirement ({REQUIRED_VERSION})")
+```bash
+python scripts/check_version.py
 ```
+
+It installs the pinned `idc-index` minimum if needed and prints a notice when a newer
+`idc-index` release (which may carry a newer IDC data version) or a newer skill version is
+available, along with the link to update. If it reports an upgrade, restart Python before
+continuing.
 
 **Verify IDC data version and check current data scale:**
 
@@ -752,5 +746,5 @@ See the Quick Navigation section at the top for the full list of reference guide
 ### Skill Updates
 
 This skill version is available in skill metadata. To check for updates:
-- Visit the [releases page](https://github.com/ImagingDataCommons/idc-claude-skill/releases)
+- Visit the [releases page](https://github.com/ImagingDataCommons/imaging-data-commons-skill/releases)
 - Watch the repository on GitHub (Watch → Custom → Releases)

--- a/USAGE.md
+++ b/USAGE.md
@@ -6,7 +6,7 @@ This document provides technical instructions for integrating the IDC Claude ski
 
 ### Install the skill
 
-1. Download the latest release ZIP from the [Releases page](https://github.com/ImagingDataCommons/idc-claude-skill/releases/latest)
+1. Download the latest release ZIP from the [Releases page](https://github.com/ImagingDataCommons/imaging-data-commons-skill/releases/latest)
 2. Open Claude Customize settings https://claude.ai/customize, select "Skills" and upload the `imaging-data-commons` skill ZIP file.
    - <img width="871" height="292" alt="2026-05-18_12-37-57" src="https://github.com/user-attachments/assets/e12a94dc-6d7f-402f-a7e6-b1c6b9cf869d" />
 
@@ -47,7 +47,7 @@ If you're using [Claude Code](https://docs.anthropic.com/en/docs/claude-code) (t
 The simplest way to install this skill using the [Skills.sh](https://skills.sh/) framework:
 
 ```bash
-npx skills add ImagingDataCommons/idc-claude-skill
+npx skills add ImagingDataCommons/imaging-data-commons-skill
 ```
 
 This command will automatically detect all AI agents on your system and offer to install the skill across all of them, making it available system-wide. Once installed, invoke with `/imaging-data-commons` or let your AI assistant auto-detect based on questions about IDC.
@@ -58,10 +58,10 @@ Link or copy the skill to your personal skills directory. This makes it availabl
 
 ```bash
 # Create a symlink (keeps skill updated with repo)
-ln -s /path/to/idc-claude-skill ~/.claude/skills/imaging-data-commons
+ln -s /path/to/imaging-data-commons-skill ~/.claude/skills/imaging-data-commons
 
 # Or copy the entire directory
-cp -r /path/to/idc-claude-skill ~/.claude/skills/imaging-data-commons
+cp -r /path/to/imaging-data-commons-skill ~/.claude/skills/imaging-data-commons
 ```
 
 Once installed, invoke with `/imaging-data-commons` or let Claude auto-detect based on your questions about IDC.
@@ -72,7 +72,7 @@ For project-specific use, link to your project's `.claude/skills/` directory:
 
 ```bash
 mkdir -p /path/to/your-project/.claude/skills
-ln -s /path/to/idc-claude-skill /path/to/your-project/.claude/skills/imaging-data-commons
+ln -s /path/to/imaging-data-commons-skill /path/to/your-project/.claude/skills/imaging-data-commons
 ```
 
 This makes the skill available only when working in that project.
@@ -82,22 +82,22 @@ This makes the skill available only when working in that project.
 For one-time use without permanent installation, ask Claude to read the skill file at the start of your session:
 
 ```
-Please read /path/to/idc-claude-skill/SKILL.md and use it for IDC queries.
+Please read /path/to/imaging-data-commons-skill/SKILL.md and use it for IDC queries.
 ```
 
 Ask Claude to load reference guides as needed for specific topics:
 
 ```
-Please also read /path/to/idc-claude-skill/references/bigquery_guide.md      # BigQuery advanced queries
-Please also read /path/to/idc-claude-skill/references/dicomweb_guide.md      # DICOMweb API access
-Please also read /path/to/idc-claude-skill/references/index_tables_guide.md  # Table schemas and join columns
-Please also read /path/to/idc-claude-skill/references/sql_patterns.md        # Quick-reference SQL patterns
-Please also read /path/to/idc-claude-skill/references/use_cases.md           # End-to-end workflow examples
-Please also read /path/to/idc-claude-skill/references/digital_pathology_guide.md  # Pathology (SM, ANN, SEG)
-Please also read /path/to/idc-claude-skill/references/clinical_data_guide.md # Clinical/tabular data
-Please also read /path/to/idc-claude-skill/references/cloud_storage_guide.md # Direct GCS/S3 access
-Please also read /path/to/idc-claude-skill/references/cli_guide.md           # idc-index CLI tools
-Please also read /path/to/idc-claude-skill/references/parquet_access_guide.md # Direct Parquet queries
+Please also read /path/to/imaging-data-commons-skill/references/bigquery_guide.md      # BigQuery advanced queries
+Please also read /path/to/imaging-data-commons-skill/references/dicomweb_guide.md      # DICOMweb API access
+Please also read /path/to/imaging-data-commons-skill/references/index_tables_guide.md  # Table schemas and join columns
+Please also read /path/to/imaging-data-commons-skill/references/sql_patterns.md        # Quick-reference SQL patterns
+Please also read /path/to/imaging-data-commons-skill/references/use_cases.md           # End-to-end workflow examples
+Please also read /path/to/imaging-data-commons-skill/references/digital_pathology_guide.md  # Pathology (SM, ANN, SEG)
+Please also read /path/to/imaging-data-commons-skill/references/clinical_data_guide.md # Clinical/tabular data
+Please also read /path/to/imaging-data-commons-skill/references/cloud_storage_guide.md # Direct GCS/S3 access
+Please also read /path/to/imaging-data-commons-skill/references/cli_guide.md           # idc-index CLI tools
+Please also read /path/to/imaging-data-commons-skill/references/parquet_access_guide.md # Direct Parquet queries
 ```
 
 ### Verifying Installation
@@ -144,6 +144,36 @@ message = client.messages.create(
     ]
 )
 ```
+
+## Keeping the Skill Up to Date
+
+The skill is refined frequently, and IDC publishes periodic (roughly quarterly) data releases. A skill that was accurate against one IDC release can return stale answers once a newer one lands, so it is worth staying current.
+
+When network access is available, the skill checks at the start of a session and prints a notice if a newer `idc-index` package or a newer skill release is available. You can also subscribe to release notifications and update manually as described below.
+
+### Get notified of new releases
+
+The skill follows [Semantic Versioning](https://semver.org/) and publishes a GitHub Release for each update. On the [repository page](https://github.com/ImagingDataCommons/imaging-data-commons-skill), click **Watch → Custom → Releases** to be alerted whenever a new version is tagged. Skim the release notes first — they flag breaking changes, such as column renames or other schema changes.
+
+### Update the skill
+
+**claude.ai and Claude Desktop** — a custom skill is updated by replacing it:
+
+1. Download the latest release ZIP from the [Releases page](https://github.com/ImagingDataCommons/imaging-data-commons-skill/releases/latest).
+2. Confirm **Code execution and file creation** is enabled under **Settings > Capabilities**.
+3. At https://claude.ai/customize, select **Skills**, delete the existing `imaging-data-commons` skill (**···** → **Delete**), and upload the new ZIP.
+
+**Claude Code** — re-run the installer to pull the latest version:
+
+```bash
+npx skills add ImagingDataCommons/imaging-data-commons-skill
+```
+
+If you installed by symlinking a local clone (USAGE Options 2–3), just `git pull` in that clone — the symlink always reflects the latest checked-out version.
+
+### Start a fresh conversation after updating
+
+A skill loads into a conversation when Claude decides it is relevant, at the session level. Updating the skill in settings does **not** change a conversation already underway. After updating, **start a new conversation** so the new version is picked up.
 
 ## Example Workflows
 
@@ -193,7 +223,7 @@ Claude: [Checks license and explains usage restrictions]
 
 - **Verify skill is loaded**: Ask Claude "What do you know about the Imaging Data Commons?" — it should give a detailed response
 - **Be specific**: Use clear questions like "Find lung CT scans in IDC" rather than just "find scans"
-- **Report issues**: If the skill fails to answer expected questions, [open an issue](https://github.com/ImagingDataCommons/idc-claude-skill/issues/new/choose)
+- **Report issues**: If the skill fails to answer expected questions, [open an issue](https://github.com/ImagingDataCommons/imaging-data-commons-skill/issues/new/choose)
 
 ### Installation Commands Fail
 
@@ -218,6 +248,6 @@ Claude: [Checks license and explains usage restrictions]
 ## Support
 
 For questions about:
-- **The skill itself**: [Open a GitHub issue](https://github.com/ImagingDataCommons/idc-claude-skill/issues)
+- **The skill itself**: [Open a GitHub issue](https://github.com/ImagingDataCommons/imaging-data-commons-skill/issues)
 - **IDC data or platform**: [IDC Forum](https://discourse.canceridc.dev/)
 - **idc-index package**: [idc-index Issues](https://github.com/ImagingDataCommons/idc-index/issues)

--- a/references/bigquery_guide.md
+++ b/references/bigquery_guide.md
@@ -648,7 +648,7 @@ ORDER BY collection_id
 - [Part 15 Appendix E - De-identification Profiles](https://dicom.nema.org/medical/dicom/current/output/chtml/part15/chapter_e.html)
 
 **Community Resources:**
-- [NAMIC Wiki: DWI/DTI DICOM](https://www.na-mic.org/wiki/NAMIC_Wiki:DTI:DICOM_for_DWI_and_DTI) - comprehensive vendor comparison for diffusion imaging
+- [NAMIC Wiki: DWI/DTI DICOM](https://web.archive.org/web/20260520044207/https://www.na-mic.org/wiki/NAMIC_Wiki:DTI:DICOM_for_DWI_and_DTI) - comprehensive vendor comparison for diffusion imaging (archived; original NA-MIC wiki retired)
 - [StandardizeBValue](https://github.com/nslay/StandardizeBValue) - tool to extract vendor b-values to standard tags
 
 ## Using Query Results with idc-index

--- a/scripts/check_version.py
+++ b/scripts/check_version.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Check the idc-index package and this skill for required/available updates.
+
+Run FIRST at the start of an IDC session:  python scripts/check_version.py
+
+- Installs the pinned, author-vetted minimum idc-index if it is missing or
+  below MIN_VERSION (does NOT auto-install newer releases).
+- Notifies (only) when a newer idc-index (PyPI) or skill release (GitHub) is
+  available. Network checks are best-effort and silently skipped offline.
+
+Keep MIN_VERSION and SKILL_VERSION in sync with the SKILL.md frontmatter.
+"""
+import subprocess
+import sys
+
+MIN_VERSION = "0.12.3"   # keep in sync with metadata.idc-index in SKILL.md
+SKILL_VERSION = "1.6.5"  # keep in sync with metadata.version in SKILL.md
+REPO = "ImagingDataCommons/imaging-data-commons-skill"
+
+
+def parse_version(v):
+    """Numeric tuple for comparison (string comparison misorders multi-digit parts)."""
+    return tuple(int(x) for x in v.lstrip("v").split(".")[:3])
+
+
+def fetch_json(url, *keys):
+    """Best-effort JSON fetch, drilling into nested keys; None if unreachable."""
+    import json
+    import urllib.request
+    try:
+        data = json.load(urllib.request.urlopen(url, timeout=5))
+        for key in keys:
+            data = data[key]
+        return data
+    except Exception:
+        return None
+
+
+def _pip_install(spec):
+    subprocess.run(
+        ["pip3", "install", "--upgrade", "--break-system-packages", spec],
+        check=True,
+    )
+
+
+def ensure_minimum():
+    """Install the pinned minimum idc-index if missing or below MIN_VERSION.
+
+    Returns the installed version string, or None if a fresh install/upgrade
+    happened and the Python process must be restarted to load it.
+    """
+    try:
+        import idc_index
+    except ImportError:
+        print(f"Installing idc-index {MIN_VERSION}...")
+        _pip_install(f"idc-index=={MIN_VERSION}")
+        print("Installed. Restart Python to use it.")
+        return None
+
+    installed = idc_index.__version__
+    if parse_version(installed) < parse_version(MIN_VERSION):
+        print(f"Upgrading idc-index {installed} -> {MIN_VERSION}...")
+        _pip_install(f"idc-index=={MIN_VERSION}")
+        print("Upgraded. Restart Python to use it.")
+        return None
+
+    print(f"idc-index {installed} meets pinned minimum ({MIN_VERSION})")
+    return installed
+
+
+def notify_updates(installed):
+    """Print notices when newer idc-index or skill versions are available."""
+    if installed:
+        pkg = fetch_json("https://pypi.org/pypi/idc-index/json", "info", "version")
+        if pkg and parse_version(pkg) > parse_version(installed):
+            print(f"ℹ️ idc-index {pkg} available — to update: pip install --upgrade idc-index")
+
+    tag = fetch_json(f"https://api.github.com/repos/{REPO}/releases/latest", "tag_name")
+    if tag and parse_version(tag) > parse_version(SKILL_VERSION):
+        print(f"ℹ️ Skill {tag.lstrip('v')} available (you have {SKILL_VERSION}): "
+              f"https://github.com/{REPO}/releases/latest")
+
+
+def main():
+    notify_updates(ensure_minimum())
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/requirements-test.txt
+++ b/tests/requirements-test.txt
@@ -1,4 +1,4 @@
-idc-index==0.12.2
+idc-index==0.12.3
 pandas
 pytest
 pytest-timeout

--- a/tests/test_snippets.py
+++ b/tests/test_snippets.py
@@ -13,10 +13,19 @@ Excluded (require auth or network I/O beyond metadata):
 BigQuery snippets are covered separately in test_bq_snippets.py (uses bq CLI dry-run).
 """
 
+import os
+import re
+import sys
+
 import pandas as pd
 import pytest
 import idc_index
 from idc_index import IDCClient
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+import check_version  # noqa: E402
+
+_SKILL_MD = os.path.join(os.path.dirname(__file__), "..", "SKILL.md")
 
 
 # ---------------------------------------------------------------------------
@@ -55,11 +64,27 @@ def client_with_all_indices(client):
 class TestVersionAndSetup:
     """SKILL.md: version check and IDC data version."""
 
-    def test_package_version_meets_requirement(self):
-        required = "0.12.2"
-        assert idc_index.__version__ >= required, (
-            f"idc-index {idc_index.__version__} < required {required}"
-        )
+    def test_package_version_meets_minimum(self):
+        assert (
+            check_version.parse_version(idc_index.__version__)
+            >= check_version.parse_version(check_version.MIN_VERSION)
+        ), f"idc-index {idc_index.__version__} < pinned minimum {check_version.MIN_VERSION}"
+
+    def test_parse_version_orders_numerically(self):
+        # String comparison would (wrongly) order "0.12.0" < "0.9.0".
+        assert check_version.parse_version("0.12.0") > check_version.parse_version("0.9.0")
+        assert check_version.parse_version("v1.6.5") == (1, 6, 5)
+
+    def test_fetch_json_returns_none_when_unreachable(self):
+        assert check_version.fetch_json("https://pypi.org/pypi/_no_such_pkg_/json", "info") is None
+
+    def test_script_versions_match_skill_frontmatter(self):
+        with open(_SKILL_MD, encoding="utf-8") as fh:
+            front = fh.read().split("---", 2)[1]
+        idc_index_meta = re.search(r'idc-index:\s*"?([\d.]+)"?', front).group(1)
+        version_meta = re.search(r"version:\s*([\d.]+)", front).group(1)
+        assert check_version.MIN_VERSION == idc_index_meta
+        assert check_version.SKILL_VERSION == version_meta
 
     def test_idc_data_version_is_v24(self, client):
         assert client.get_idc_version() == "v24"


### PR DESCRIPTION
- Session-start notify-only checks: warn when a newer idc-index (PyPI) or skill version (GitHub Releases) is available; never auto-install, fail silently offline. Install still pins to an author-vetted MIN_VERSION.
- Switch version comparison from string to numeric tuple comparison; fix idc-index version drift (0.12.2 vs 0.12.3) -> 0.12.3.
- Rename repository references idc-claude-skill -> imaging-data-commons-skill across SKILL.md, README.md, USAGE.md.
- Add "Keeping the Skill Up to Date" section to USAGE.md; link from README.
- Bump version to 1.6.5 and add CHANGELOG entry.