### PR TITLE
Make documentation vendor-neutral after repo rename

### DIFF
--- a/.github/ISSUE_TEMPLATE/skill-issue.yml
+++ b/.github/ISSUE_TEMPLATE/skill-issue.yml
@@ -6,7 +6,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for taking the time to report an issue with the IDC Claude skill!
+        Thanks for taking the time to report an issue with the Imaging Data Commons skill!
         
         Please provide as much detail as possible to help us understand and fix the problem.
 
@@ -14,7 +14,7 @@ body:
     id: question-asked
     attributes:
       label: Question Asked
-      description: What question did you ask Claude (with the IDC skill loaded)?
+      description: What question did you ask your AI assistant (with the IDC skill loaded)?
       placeholder: "Example: Find all CT scans of lung cancer with commercial-use licenses"
     validations:
       required: true
@@ -43,7 +43,7 @@ body:
       label: Additional Context
       description: |
         Add any other context about the problem here:
-        - Which AI assistant are you using? (Claude Desktop, API, other)
+        - Which AI assistant are you using? (claude.ai, Claude Desktop, Claude Code, another agent, direct API)
         - Have similar questions worked in the past?
         - Any error messages or unusual behavior?
       placeholder: "Any additional details that might help..."
@@ -56,7 +56,7 @@ body:
       label: Pre-submission Checklist
       description: Please confirm the following before submitting
       options:
-        - label: I have verified the skill is properly loaded (Claude confirms it has access to IDC information)
+        - label: I have verified the skill is properly loaded (the assistant confirms it has access to IDC information)
           required: true
         - label: I have checked existing issues to avoid duplicates
           required: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,17 @@
 # Changelog
 
-All notable changes to the IDC Claude Skill are documented in this file.
+All notable changes to the Imaging Data Commons Skill are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
+
+## [Unreleased]
+
+### Changed
+
+- Repository renamed from `idc-claude-skill` to `imaging-data-commons-skill` on GitHub to reflect that the skill is not specific to Claude
+- Made `README.md`, `USAGE.md`, `CHANGELOG.md`, the issue template, and test docstrings vendor-neutral: the skill is described as an Agent Skills–format skill usable with any compatible AI assistant; Claude-specific setup instructions remain as one supported environment
+- Promoted the `npx skills add` cross-agent installation to the top of `USAGE.md`; renamed "Claude API Setup" to "API Setup"
 
 ## [1.6.5] - 2026-06-17
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# IDC Claude Skill
+# Imaging Data Commons Skill
 
-A Claude AI skill for querying and downloading public cancer imaging data from the National Cancer Institute's [Imaging Data Commons (IDC)](https://imaging.datacommons.cancer.gov/).
+An AI agent skill for querying and downloading public cancer imaging data from the National Cancer Institute's [Imaging Data Commons (IDC)](https://imaging.datacommons.cancer.gov/). The skill follows the open [Agent Skills](https://agentskills.io/) format and is not specific to any single AI assistant — it works with Claude (claude.ai, Claude Desktop, Claude Code, API) and any other agent that supports the skill format or can load the skill content into its context.
 
 ## What This Skill Does
 
@@ -25,7 +25,7 @@ If the skill provides incorrect or incomplete answers, please [open an issue](ht
 
 ## Setup Instructions
 
-See [USAGE.md](USAGE.md) for detailed instructions on loading this skill in Claude Desktop or via the API.
+See [USAGE.md](USAGE.md) for detailed instructions on loading this skill in your AI assistant environment (claude.ai, Claude Desktop, Claude Code, other agents, or via an LLM API).
 
 ## Versioning
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -1,6 +1,16 @@
 # Usage Instructions
 
-This document provides technical instructions for integrating the IDC Claude skill into your AI assistant environment.
+This document provides technical instructions for integrating the Imaging Data Commons skill into your AI assistant environment. The skill is not specific to any single vendor: it follows the open [Agent Skills](https://agentskills.io/) format, so it works with any agent that supports that format, and its content can be loaded as plain Markdown into any other assistant.
+
+## Quick Install for Coding Agents (Recommended)
+
+The simplest way to install this skill is with the [Skills.sh](https://skills.sh/) framework:
+
+```bash
+npx skills add ImagingDataCommons/imaging-data-commons-skill
+```
+
+This command automatically detects the AI agents installed on your system (Claude Code, Codex, Cursor, Gemini CLI, and others) and offers to install the skill across all of them, making it available system-wide. Once installed, invoke with `/imaging-data-commons` or let your AI assistant auto-detect based on questions about IDC.
 
 ## Claude.ai Web Interface
 
@@ -40,19 +50,9 @@ Claude should respond with specific information about IDC, the `idc-index` packa
 
 ## Claude Code Setup
 
-If you're using [Claude Code](https://docs.anthropic.com/en/docs/claude-code) (the CLI tool), you can install the skill for persistent access.
+If you're using [Claude Code](https://docs.anthropic.com/en/docs/claude-code) (the CLI tool), the `npx skills add` command above is the easiest option. Alternatively, install manually as described below. Other agents that support the Agent Skills format work the same way — just substitute their skills directory (e.g. `~/.claude/skills/` becomes the equivalent location for your agent).
 
-### Option 1: Install via npx (Recommended)
-
-The simplest way to install this skill using the [Skills.sh](https://skills.sh/) framework:
-
-```bash
-npx skills add ImagingDataCommons/imaging-data-commons-skill
-```
-
-This command will automatically detect all AI agents on your system and offer to install the skill across all of them, making it available system-wide. Once installed, invoke with `/imaging-data-commons` or let your AI assistant auto-detect based on questions about IDC.
-
-### Option 2: Install as Personal Skill
+### Option 1: Install as Personal Skill
 
 Link or copy the skill to your personal skills directory. This makes it available across all projects:
 
@@ -66,7 +66,7 @@ cp -r /path/to/imaging-data-commons-skill ~/.claude/skills/imaging-data-commons
 
 Once installed, invoke with `/imaging-data-commons` or let Claude auto-detect based on your questions about IDC.
 
-### Option 3: Install as Project Skill
+### Option 2: Install as Project Skill
 
 For project-specific use, link to your project's `.claude/skills/` directory:
 
@@ -77,15 +77,15 @@ ln -s /path/to/imaging-data-commons-skill /path/to/your-project/.claude/skills/i
 
 This makes the skill available only when working in that project.
 
-### Option 4: Import During Session
+### Option 3: Import During Session
 
-For one-time use without permanent installation, ask Claude to read the skill file at the start of your session:
+For one-time use without permanent installation, ask your assistant to read the skill file at the start of your session:
 
 ```
 Please read /path/to/imaging-data-commons-skill/SKILL.md and use it for IDC queries.
 ```
 
-Ask Claude to load reference guides as needed for specific topics:
+Ask your assistant to load reference guides as needed for specific topics:
 
 ```
 Please also read /path/to/imaging-data-commons-skill/references/bigquery_guide.md      # BigQuery advanced queries
@@ -102,7 +102,7 @@ Please also read /path/to/imaging-data-commons-skill/references/parquet_access_g
 
 ### Verifying Installation
 
-After installing, verify by asking Claude:
+After installing, verify by asking your assistant:
 ```
 What skills do you have for medical imaging data?
 ```
@@ -112,11 +112,11 @@ Or invoke directly:
 /imaging-data-commons
 ```
 
-## Claude API Setup
+## API Setup
 
-If you're using the Claude API directly, include the contents of `SKILL.md` in your system prompt. Include additional reference guides from [references/](references/) as needed for advanced features.
+If you're calling an LLM API directly (any provider), include the contents of `SKILL.md` in your system prompt. Include additional reference guides from [references/](references/) as needed for advanced features.
 
-### Example with Anthropic API
+### Example with the Anthropic API
 
 ```python
 import anthropic
@@ -163,17 +163,17 @@ The skill follows [Semantic Versioning](https://semver.org/) and publishes a Git
 2. Confirm **Code execution and file creation** is enabled under **Settings > Capabilities**.
 3. At https://claude.ai/customize, select **Skills**, delete the existing `imaging-data-commons` skill (**···** → **Delete**), and upload the new ZIP.
 
-**Claude Code** — re-run the installer to pull the latest version:
+**Claude Code and other coding agents** — re-run the installer to pull the latest version:
 
 ```bash
 npx skills add ImagingDataCommons/imaging-data-commons-skill
 ```
 
-If you installed by symlinking a local clone (USAGE Options 2–3), just `git pull` in that clone — the symlink always reflects the latest checked-out version.
+If you installed by symlinking a local clone (USAGE Options 1–2), just `git pull` in that clone — the symlink always reflects the latest checked-out version.
 
 ### Start a fresh conversation after updating
 
-A skill loads into a conversation when Claude decides it is relevant, at the session level. Updating the skill in settings does **not** change a conversation already underway. After updating, **start a new conversation** so the new version is picked up.
+A skill loads into a conversation when the assistant decides it is relevant, at the session level. Updating the skill in settings does **not** change a conversation already underway. After updating, **start a new conversation** so the new version is picked up.
 
 ## Example Workflows
 
@@ -181,29 +181,29 @@ A skill loads into a conversation when Claude decides it is relevant, at the ses
 
 ```
 User: "What collections in IDC have prostate MRI data?"
-Claude: [Uses skill to query and list relevant collections]
+Assistant: [Uses skill to query and list relevant collections]
 ```
 
 ### Download Dataset
 
 ```
 User: "Download all CT scans from the NSCLC-Radiomics collection"
-Claude: [Provides idc-index download command with proper parameters]
+Assistant: [Provides idc-index download command with proper parameters]
 ```
 
 ### License Checking
 
 ```
 User: "Can I use TCGA-BRCA data for commercial purposes?"
-Claude: [Checks license and explains usage restrictions]
+Assistant: [Checks license and explains usage restrictions]
 ```
 
 ## Limitations
 
 ### Command Execution
 
-- **Claude Desktop**: Can execute commands directly (e.g., installing `idc-index` with pip)
-- **Other AI Assistants**: May only provide guidance without executing commands. Users will need to manually run installation commands like `pip install idc-index`
+- **Assistants with code execution** (e.g., Claude Desktop, Claude Code, other coding agents): Can execute commands directly, such as installing `idc-index` with pip
+- **Assistants without code execution**: Can only provide guidance. Users will need to manually run installation commands like `pip install idc-index`
 
 ### Data Access
 
@@ -215,13 +215,13 @@ Claude: [Checks license and explains usage restrictions]
 
 ### Skill Not Loading
 
-- **Claude Code**: Verify the symlink exists at `~/.claude/skills/imaging-data-commons` and points to the correct directory
+- **Claude Code and other coding agents**: Verify the symlink exists in the agent's skills directory (e.g., `~/.claude/skills/imaging-data-commons`) and points to the correct location
 - **ZIP attachment** (Claude.ai): Ensure the release ZIP is attached to your conversation before asking IDC-related questions
-- **File size**: The ZIP file is large. If Claude seems unaware of IDC, the file may not have been fully loaded
+- **File size**: The ZIP file is large. If the assistant seems unaware of IDC, the file may not have been fully loaded
 
 ### Skill Not Responding as Expected
 
-- **Verify skill is loaded**: Ask Claude "What do you know about the Imaging Data Commons?" — it should give a detailed response
+- **Verify skill is loaded**: Ask your assistant "What do you know about the Imaging Data Commons?" — it should give a detailed response
 - **Be specific**: Use clear questions like "Find lung CT scans in IDC" rather than just "find scans"
 - **Report issues**: If the skill fails to answer expected questions, [open an issue](https://github.com/ImagingDataCommons/imaging-data-commons-skill/issues/new/choose)
 

--- a/tests/test_snippets.py
+++ b/tests/test_snippets.py
@@ -1,5 +1,5 @@
 """
-Regression tests for all queries and code snippets documented in the IDC Claude Skill.
+Regression tests for all queries and code snippets documented in the Imaging Data Commons Skill.
 
 Covers: SKILL.md, references/sql_patterns.md, references/index_tables_guide.md,
         references/clinical_data_guide.md


### PR DESCRIPTION
## Summary

The repository was renamed from `idc-claude-skill` to `imaging-data-commons-skill` to reflect that the skill is not specific to Claude. This PR updates the remaining old-name references and makes the documentation vendor-neutral:

- **README.md** — retitled to "Imaging Data Commons Skill"; the skill is now described as an [Agent Skills](https://agentskills.io/)-format skill that works with Claude and any other compatible AI assistant
- **USAGE.md** — the cross-agent `npx skills add` install now leads as the recommended path; "Claude API Setup" renamed to "API Setup" (Anthropic snippet kept as an example); generic guidance, example dialogues, limitations, and troubleshooting now say "your assistant" instead of "Claude". Sections documenting Claude products (claude.ai, Claude Desktop, Claude Code) keep their names as one supported environment among others
- **Issue template** — asks about "your AI assistant" with a broader list of environments
- **CHANGELOG.md** — header neutralized; added an Unreleased entry documenting the rename (the historical 1.6.5 entry is left untouched)
- **tests/test_snippets.py** — docstring updated

`SKILL.md`, `scripts/check_version.py`, and the workflows already pointed at the new repo name and needed no changes. The only remaining `idc-claude-skill` strings are the intentional CHANGELOG mentions describing the rename itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)