### PR TITLE
MCP server coordination, check_version.py fix, and 1.7.0 release

### DIFF
--- a/.github/workflows/test-snippets.yml
+++ b/.github/workflows/test-snippets.yml
@@ -6,12 +6,14 @@ on:
       - main
     paths:
       - 'SKILL.md'
+      - 'USAGE.md'
       - 'references/**'
       - 'tests/**'
       - '.github/workflows/test-snippets.yml'
   pull_request:
     paths:
       - 'SKILL.md'
+      - 'USAGE.md'
       - 'references/**'
       - 'tests/**'
       - '.github/workflows/test-snippets.yml'
@@ -40,3 +42,7 @@ jobs:
 
       - name: Run snippet tests
         run: pytest tests/test_snippets.py -v --timeout=300
+
+      # Skips (does not fail) when the hosted MCP server is unreachable.
+      - name: Run IDC MCP server contract tests
+        run: pytest tests/test_mcp_server.py -v --timeout=120

--- a/.github/workflows/test-snippets.yml
+++ b/.github/workflows/test-snippets.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/cache@v6
         with:
           path: ~/.idc
-          key: idc-index-0.12.3
+          key: idc-index-0.12.5
 
       - name: Install test dependencies
         run: pip install -r tests/requirements-test.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - "IDC MCP Server" section in `SKILL.md` and `references/mcp_guide.md`, covering IDC's hosted MCP server at `https://api.imaging.datacommons.cancer.gov/mcp` (streamable HTTP, no authentication): how to recognize it, how to divide work between it and `idc-index`, and how to hand off SeriesInstanceUIDs for download
 - Guidance to identify the server by its `idc://guide` MCP resource or a fingerprint of three or more IDC-specific tool names, and to fall back to `idc-index` whenever identification is ambiguous — generic tool names such as `run_sql` are explicitly not treated as evidence
 - "IDC MCP Server (Optional)" section in `USAGE.md` with the endpoint, when adding it is worthwhile, and a Claude Code registration example
+- `tests/test_mcp_server.py`: contract tests that parse the documented tool fingerprint and inventory out of `SKILL.md` / `references/mcp_guide.md` and check them against the live server, so the docs cannot drift silently as the beta server evolves; network tests skip rather than fail when the server is unreachable, and the offline checks guard URL consistency and keep generic tool names out of the fingerprint
+- `USAGE.md` to the `test-snippets.yml` path filter, since the new tests read it
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- "IDC MCP Server" section in `SKILL.md` and `references/mcp_guide.md`, covering IDC's hosted MCP server at `https://api.imaging.datacommons.cancer.gov/mcp` (streamable HTTP, no authentication): how to recognize it, how to divide work between it and `idc-index`, and how to hand off SeriesInstanceUIDs for download
+- Guidance to identify the server by its `idc://guide` MCP resource or a fingerprint of three or more IDC-specific tool names, and to fall back to `idc-index` whenever identification is ambiguous — generic tool names such as `run_sql` are explicitly not treated as evidence
+- "IDC MCP Server (Optional)" section in `USAGE.md` with the endpoint, when adding it is worthwhile, and a Claude Code registration example
+
 ### Changed
 
 - Repository renamed from `idc-claude-skill` to `imaging-data-commons-skill` on GitHub to reflect that the skill is not specific to Claude

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the Imaging Data Commons Skill are documented in this fil
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [1.7.0] - 2026-07-31
 
 ### Added
 
@@ -14,13 +14,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - "IDC MCP Server (Optional)" section in `USAGE.md` with the endpoint, when adding it is worthwhile, and a Claude Code registration example
 - `tests/test_mcp_server.py`: contract tests that parse the documented tool fingerprint and inventory out of `SKILL.md` / `references/mcp_guide.md` and check them against the live server, so the docs cannot drift silently as the beta server evolves; network tests skip rather than fail when the server is unreachable, and the offline checks guard URL consistency and keep generic tool names out of the fingerprint
 - `USAGE.md` to the `test-snippets.yml` path filter, since the new tests read it
+- Snippet test coverage for `references/use_cases.md`, `references/digital_pathology_guide.md`, and `references/parquet_access_guide.md`, which had none: 31 tests covering the use-case selection queries, every slide microscopy / annotation / segmentation query in the pathology guide, and the DuckDB-over-HTTPS Parquet queries. The pathology tests assert the TCGA-BRCA slide counts quoted inline in that guide (2704 primary / 399 normal, barcode sample types 01/06/11), so a data release that moves them fails CI instead of silently making the prose wrong
+- `TestParquetAccessGuide` checks that every Parquet file listed in the guide exists under `current/` and that `current/` resolves to the installed `idc-index-data` release
 
 ### Changed
 
 - Moved the MCP-vs-`idc-index` routing decision into the `SKILL.md` Overview, next to "Primary tool", so a session that already has the MCP server can skip the `idc-index` setup instead of discovering the alternative only after running it; `idc-index` remains the primary, always-available path and the version-check step is unconditional again
+- `scripts/check_version.py` no longer installs anything: when `idc-index` is missing or below the pinned minimum it prints the `pip install` command for the running interpreter and exits non-zero, leaving the choice of environment to the user. `SKILL.md` documents the new behavior
+- Updated to idc-index 0.12.5 (idc-index-data 24.2.2); IDC data version remains v24. 0.12.5 relaxes the dependency to `pandas>=2.2.2,<4`, so installing the skill's pinned minimum no longer downgrades a pandas 3.x environment (verified: 0.12.5 installs alongside pandas 3.0.5)
+- Refreshed the stale `Tested with:` headers in `references/`: `use_cases.md`, `clinical_data_guide.md`, and `digital_pathology_guide.md` claimed idc-index 0.12.1, and `parquet_access_guide.md` claimed idc-index-data 23.10.1. All snippets were re-run against idc-index 0.12.5 / idc-index-data 24.2.2 before the headers were updated. `bigquery_guide.md` now names the BigQuery dataset it was validated against (`bigquery-public-data.idc_current`, via `bq query --dry_run`) rather than an idc-index version its SQL does not use
 - Repository renamed from `idc-claude-skill` to `imaging-data-commons-skill` on GitHub to reflect that the skill is not specific to Claude
 - Made `README.md`, `USAGE.md`, `CHANGELOG.md`, the issue template, and test docstrings vendor-neutral: the skill is described as an Agent Skills–format skill usable with any compatible AI assistant; Claude-specific setup instructions remain as one supported environment
 - Promoted the `npx skills add` cross-agent installation to the top of `USAGE.md`; renamed "Claude API Setup" to "API Setup"
+
+### Security
+
+- Removed the `pip3 install --upgrade --break-system-packages` call from `scripts/check_version.py`. It bypassed the PEP 668 guard on externally managed interpreters, and — combined with the `pandas<=2.2.4` cap in idc-index ≤ 0.12.4 — could silently downgrade a system-wide pandas 3.x as a side effect of a version *check*. It also invoked whatever `pip3` resolved to on `PATH`, which is not necessarily the running interpreter's pip, so an install could land in a different environment than the one that failed to import `idc_index`. Reported in review of K-Dense-AI/scientific-agent-skills#158
+
+### Fixed
+
+- `parse_version` in `scripts/check_version.py` no longer raises on pre-release or suffixed tags (`0.13.0rc1`, `v1.7.0-beta`); it takes the leading digits of each component and pads to three, so an upstream pre-release cannot crash the startup check. Pre-releases compare equal to their base release, keeping update notices conservative
 
 ## [1.6.5] - 2026-06-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- Moved the MCP-vs-`idc-index` routing decision into the `SKILL.md` Overview, next to "Primary tool", so a session that already has the MCP server can skip the `idc-index` setup instead of discovering the alternative only after running it; `idc-index` remains the primary, always-available path and the version-check step is unconditional again
 - Repository renamed from `idc-claude-skill` to `imaging-data-commons-skill` on GitHub to reflect that the skill is not specific to Claude
 - Made `README.md`, `USAGE.md`, `CHANGELOG.md`, the issue template, and test docstrings vendor-neutral: the skill is described as an Agent Skills–format skill usable with any compatible AI assistant; Claude-specific setup instructions remain as one supported environment
 - Promoted the `npx skills add` cross-agent installation to the top of `USAGE.md`; renamed "Claude API Setup" to "API Setup"

--- a/SKILL.md
+++ b/SKILL.md
@@ -20,10 +20,14 @@ Use the `idc-index` Python package to query and download public cancer imaging d
 
 **Current IDC Data Version: v24** (always verify with `IDCClient().get_idc_version()`)
 
-**Primary tool:** `idc-index` ([GitHub](https://github.com/imagingdatacommons/idc-index))
+**Primary tool:** `idc-index` ([GitHub](https://github.com/imagingdatacommons/idc-index)) — the
+default path, always available.
 
-**CRITICAL - run this FIRST**, before any IDC query that uses `idc-index` (if this session
-already has the hosted IDC MCP server, read *IDC MCP Server* below first):
+**First, check your session:** if it already has the hosted IDC MCP server, route discovery and
+metadata there and skip the setup below — see *IDC MCP Server*. Return here for downloads and
+local analysis. Otherwise continue straight through.
+
+**CRITICAL - run this FIRST**, before any IDC query that uses `idc-index`:
 
 ```bash
 python scripts/check_version.py

--- a/SKILL.md
+++ b/SKILL.md
@@ -3,9 +3,9 @@ name: imaging-data-commons
 description: Query and download public cancer imaging data from NCI Imaging Data Commons using idc-index. Invoke for any question about IDC collections, cancer imaging datasets, DICOM data access, radiology (CT, MR, PET) or pathology AI training sets, metadata queries, visualization, or license checks — even when the user doesn't explicitly mention "IDC". No authentication required.
 license: This skill is provided under the MIT License. IDC data itself has individual licensing (mostly CC-BY, some CC-NC) that must be respected when using the data.
 metadata:
-    version: 1.6.5
+    version: 1.7.0
     skill-author: Andrey Fedorov, @fedorov
-    idc-index: "0.12.3"
+    idc-index: "0.12.5"
     idc-data-version: "v24"
     repository: https://github.com/ImagingDataCommons/imaging-data-commons-skill
 ---
@@ -33,10 +33,13 @@ local analysis. Otherwise continue straight through.
 python scripts/check_version.py
 ```
 
-It installs the pinned `idc-index` minimum if needed and prints a notice when a newer
-`idc-index` release (which may carry a newer IDC data version) or a newer skill version is
-available, along with the link to update. If it reports an upgrade, restart Python before
-continuing.
+It checks the installed `idc-index` against the pinned minimum and prints a notice when a
+newer `idc-index` release (which may carry a newer IDC data version) or a newer skill version
+is available, along with the link to update.
+
+The script never installs or upgrades anything itself. If the pinned minimum is missing it
+exits non-zero and prints the exact `pip install` command for the running interpreter — run
+that command, preferring a virtual environment, then restart Python before continuing.
 
 **Verify IDC data version and check current data scale:**
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -22,7 +22,8 @@ Use the `idc-index` Python package to query and download public cancer imaging d
 
 **Primary tool:** `idc-index` ([GitHub](https://github.com/imagingdatacommons/idc-index))
 
-**CRITICAL - run this FIRST**, before any IDC query:
+**CRITICAL - run this FIRST**, before any IDC query that uses `idc-index` (if this session
+already has the hosted IDC MCP server, read *IDC MCP Server* below first):
 
 ```bash
 python scripts/check_version.py
@@ -62,6 +63,35 @@ print(stats)
 2. Download DICOM files → `client.download_from_selection()`
 3. Visualize in browser → `client.get_viewer_URL(seriesInstanceUID=...)`
 
+## IDC MCP Server
+
+IDC operates a hosted MCP server at `https://api.imaging.datacommons.cancer.gov/mcp`
+(streamable HTTP, no authentication). Where it is available it complements — it does not
+replace — the `idc-index` workflow below.
+
+**Identify it** by the MCP resource `idc://guide`, or by three or more of the tool names
+`build_cohort`, `get_cohort_urls`, `list_analysis_results`, and `get_idc_version`. Generic
+names such as `run_sql` are not evidence on their own. If identification is ambiguous, use
+`idc-index`.
+
+**If this session has the server**, treat it as authoritative for discovery and metadata —
+IDC version, counts, attribute values, cohort building, metadata SQL — and follow the
+server's own instructions rather than re-deriving them from this file. Its data version is
+whatever the server reports: call `get_idc_version` instead of relying on the version pinned
+in this file.
+
+Return here for what the server does not do: downloading files, local pandas/notebook
+analysis, DICOMweb, BigQuery, digital pathology tiling, and reproducible scripts. Hand off by
+passing SeriesInstanceUIDs from the server to `client.download_from_selection(...)`, and run
+`scripts/check_version.py` at that point.
+
+**If it is not available**, use `idc-index` below — the default, fully capable path. Mention
+the endpoint once only if the task would clearly benefit (repeated interactive discovery, or
+no local Python), and let the user decide how to connect it. Do not change their
+configuration, and do not repeat the suggestion.
+
+See `references/mcp_guide.md` for the tool inventory, handoff patterns, and per-host notes.
+
 ## When to Use This Skill
 
 - Finding publicly available radiology (CT, MR, PET) or pathology (slide microscopy) images
@@ -73,6 +103,7 @@ print(stats)
 ## Quick Navigation
 
 **Core Sections (inline):**
+- IDC MCP Server - When to route discovery and metadata to the hosted server
 - IDC Data Model - Collection and analysis result hierarchy
 - Index Tables - Available tables and joining patterns
 - Core Capabilities - Essential API patterns (query, download, visualize, license, citations)
@@ -93,6 +124,7 @@ print(stats)
 | `bigquery_guide.md` | Full DICOM metadata, private elements (requires GCP) |
 | `cli_guide.md` | Command-line tools (`idc download`, manifest files) |
 | `parquet_access_guide.md` | Direct Parquet queries via GCS (no idc-index install needed) |
+| `mcp_guide.md` | Hosted IDC MCP server: tool inventory, identification, handoff to `idc-index` |
 
 ## IDC Data Model
 
@@ -200,6 +232,7 @@ See `references/clinical_data_guide.md` for detailed workflows including value m
 | Method | Auth Required | Best For |
 |--------|---------------|----------|
 | `idc-index` | No | Key queries and downloads (recommended) |
+| IDC MCP server | No | Discovery, cohort building, and metadata when the session already has it |
 | Direct Parquet (GCS) | No | Quick queries without installing idc-index; always uses latest data |
 | IDC Portal | No | Interactive exploration, manual selection, browser-based download |
 | BigQuery | Yes (GCP account) | Complex queries, full DICOM metadata |
@@ -643,6 +676,7 @@ See `references/bigquery_guide.md` for schemas, column descriptions, and query e
 | Task | Tool | Reference |
 |------|------|-----------|
 | Programmatic queries & downloads | `idc-index` | This document |
+| Discovery & cohort building, when the session has the hosted MCP server | IDC MCP server | `references/mcp_guide.md` |
 | Interactive exploration | IDC Portal | https://portal.imaging.datacommons.cancer.gov/ |
 | Complex metadata queries | BigQuery | `references/bigquery_guide.md` |
 | 3D visualization & analysis | SlicerIDCBrowser | https://github.com/ImagingDataCommons/SlicerIDCBrowser |

--- a/USAGE.md
+++ b/USAGE.md
@@ -98,6 +98,7 @@ Please also read /path/to/imaging-data-commons-skill/references/clinical_data_gu
 Please also read /path/to/imaging-data-commons-skill/references/cloud_storage_guide.md # Direct GCS/S3 access
 Please also read /path/to/imaging-data-commons-skill/references/cli_guide.md           # idc-index CLI tools
 Please also read /path/to/imaging-data-commons-skill/references/parquet_access_guide.md # Direct Parquet queries
+Please also read /path/to/imaging-data-commons-skill/references/mcp_guide.md            # Hosted IDC MCP server
 ```
 
 ### Verifying Installation
@@ -111,6 +112,40 @@ Or invoke directly:
 ```
 /imaging-data-commons
 ```
+
+## IDC MCP Server (Optional)
+
+IDC operates a hosted [MCP](https://modelcontextprotocol.io/) server that exposes IDC
+discovery, cohort building, and metadata queries as agent tools:
+
+| Property | Value |
+|----------|-------|
+| URL | `https://api.imaging.datacommons.cancer.gov/mcp` |
+| Transport | Streamable HTTP |
+| Authentication | None |
+
+This is optional and independent of the skill — the skill is fully functional without it. When
+both are present, the skill routes discovery and metadata to the server and keeps downloads,
+local analysis, DICOMweb, and BigQuery for `idc-index`. See
+[references/mcp_guide.md](references/mcp_guide.md) for the full division of labor.
+
+Adding the server is worthwhile if you do a lot of interactive exploration, or if you work in
+an assistant without local Python. If you mainly download data and analyze it locally, the
+skill alone is enough.
+
+Registration is agent-specific; consult your agent's MCP documentation. For Claude Code:
+
+```bash
+claude mcp add --transport http idc https://api.imaging.datacommons.cancer.gov/mcp
+```
+
+On claude.ai, add it under [Settings > Connectors](https://claude.ai/customize/connectors) as
+a custom connector with the URL above.
+
+Two Claude Code notes if you write permission rules: tools are namespaced by the server name
+you choose, so a CLI install named `idc` produces `mcp__idc__*` while a claude.ai connector
+produces `mcp__claude_ai_<name>__*`. Allow rules require a literal server segment —
+`mcp__idc__*` works, `mcp__*` is ignored.
 
 ## API Setup
 
@@ -240,7 +275,7 @@ Assistant: [Checks license and explains usage restrictions]
 ## Resources
 
 - [SKILL.md](SKILL.md) - Comprehensive skill documentation
-- [references/](references/) - Reference guides (BigQuery, DICOMweb, SQL patterns, pathology, clinical data, cloud storage, CLI, Parquet)
+- [references/](references/) - Reference guides (BigQuery, DICOMweb, SQL patterns, pathology, clinical data, cloud storage, CLI, Parquet, MCP server)
 - [IDC Documentation](https://learn.canceridc.dev/)
 - [idc-index Package](https://pypi.org/project/idc-index/)
 - [IDC Portal](https://portal.imaging.datacommons.cancer.gov/)

--- a/references/bigquery_guide.md
+++ b/references/bigquery_guide.md
@@ -1,6 +1,6 @@
 # BigQuery Guide for IDC
 
-**Tested with:** idc-index 0.12.1 (IDC data version v24)
+**Tested with:** `bigquery-public-data.idc_current` and idc-index 0.12.5 (IDC data version v24)
 
 For most queries and downloads, use `idc-index` (see main SKILL.md). This guide covers BigQuery for advanced use cases requiring full DICOM metadata or complex joins.
 

--- a/references/clinical_data_guide.md
+++ b/references/clinical_data_guide.md
@@ -1,6 +1,6 @@
 # Clinical Data Guide for IDC
 
-**Tested with:** idc-index 0.12.1 (IDC data version v24)
+**Tested with:** idc-index 0.12.5 (IDC data version v24)
 
 Clinical data (demographics, diagnoses, therapies, lab tests, staging) accompanies many IDC imaging collections. This guide covers how to discover, access, and integrate clinical data with imaging data using `idc-index`.
 

--- a/references/digital_pathology_guide.md
+++ b/references/digital_pathology_guide.md
@@ -1,6 +1,6 @@
 # Digital Pathology Guide for IDC
 
-**Tested with:** idc-index 0.12.1 (IDC data version v24)
+**Tested with:** idc-index 0.12.5 (IDC data version v24)
 
 For general IDC queries and downloads, use `idc-index` (see main SKILL.md). This guide covers slide microscopy (SM) imaging, microscopy bulk simple annotations (ANN), and segmentations (SEG) in the context of digital pathology in IDC.
 

--- a/references/index_tables_guide.md
+++ b/references/index_tables_guide.md
@@ -1,6 +1,6 @@
 # Index Tables Guide for IDC
 
-**Tested with:** idc-index 0.12.3 (IDC data version v24)
+**Tested with:** idc-index 0.12.5 (IDC data version v24)
 
 This guide covers the structure and access patterns for IDC index tables: programmatic schema discovery, DataFrame access, and join column references. For the overview of available tables and their purposes, see the "Index Tables" section in the main SKILL.md.
 

--- a/references/mcp_guide.md
+++ b/references/mcp_guide.md
@@ -1,0 +1,172 @@
+# IDC MCP Server Guide
+
+IDC operates a hosted [Model Context Protocol](https://modelcontextprotocol.io/) server that
+exposes IDC discovery and metadata as agent tools. This guide covers how to recognize it, how
+to divide work between it and `idc-index`, and what to hand off across that boundary.
+
+The server is optional. Everything in `SKILL.md` works without it.
+
+## Endpoint
+
+| Property | Value |
+|----------|-------|
+| URL | `https://api.imaging.datacommons.cancer.gov/mcp` |
+| Transport | Streamable HTTP (`streamable-http`, sometimes spelled `http`) |
+| Authentication | None |
+| Server identity | `IDC (Imaging Data Commons)` |
+
+## Identifying the server
+
+Tool names and resource URIs are defined by the server, so they are the same on every host.
+Use them, not host-specific naming conventions, to decide whether the server is present.
+
+**Strongest signal — resource URIs.** The server publishes two resources under an `idc://`
+scheme:
+
+| URI | Content |
+|-----|---------|
+| `idc://guide` | Data model and recommended workflow (Markdown) |
+| `idc://tables` | Tables available to `run_sql`, with descriptions and column counts (JSON) |
+
+If the host can enumerate MCP resources, a resource with URI `idc://guide` identifies the
+server unambiguously.
+
+**Fallback — tool-name fingerprint.** Require three or more of `build_cohort`,
+`get_cohort_urls`, `list_analysis_results`, and `get_idc_version`. Do not treat `run_sql`,
+`get_stats`, `list_tables`, or `get_citations` as evidence on their own; those names are
+generic enough that another server could expose them.
+
+**This is disambiguation, not authentication.** No runtime check can prove the server on the
+other end is operated by NCI — a hostile server could serve `idc://guide` and name its tools
+anything. The trust anchor is the URL the user configured plus TLS, which is established when
+the server is added, not when the skill runs. That is sufficient for routing: the check only
+has to distinguish IDC from the user's other installed servers.
+
+**Fail soft.** If identification is ambiguous, or a tool call fails, fall back to `idc-index`
+rather than reporting an error. Tool names may change as the server matures.
+
+## Tool inventory
+
+Verified against server version `3.0.0b2`. Treat this as a snapshot, not a contract — call
+the server's own listing rather than assuming this list is current.
+
+| Group | Tools |
+|-------|-------|
+| Version and scale | `get_idc_version`, `get_stats` |
+| Collections | `list_collections`, `get_collection`, `list_analysis_results` |
+| Attribute grounding | `list_attributes`, `get_attribute_values` |
+| Cohorts | `build_cohort`, `get_cohort_urls` |
+| SQL | `list_tables`, `get_table_schema`, `run_sql` |
+| Clinical data | `list_clinical_tables`, `get_clinical_table_schema`, `get_clinical_table` |
+| Attribution | `get_citations`, `get_licenses` |
+| Visualization | `get_viewer_url` |
+
+The server ships its own usage instructions, which most hosts inject automatically. Follow
+those instructions for tool sequencing (ground with `list_attributes` /
+`get_attribute_values` before filtering; check `list_tables` before writing SQL). Do not
+re-derive that workflow from `SKILL.md` — the two would drift apart on the server's next
+release.
+
+## Division of labor
+
+The server and `idc-index` overlap on metadata queries and diverge everywhere else.
+
+| Task | Use |
+|------|-----|
+| IDC data version, collection and series counts | Server (`get_idc_version`, `get_stats`) |
+| Valid filter values before building a query | Server (`get_attribute_values`) |
+| Cohort selection by attribute filters | Server (`build_cohort`) |
+| One-off metadata SQL, answer consumed as prose | Server (`run_sql`) |
+| Metadata SQL whose result feeds local Python | `idc-index` (`client.sql_query`) |
+| Downloading DICOM files | `idc-index` (`client.download_from_selection`) |
+| pandas / notebook analysis, plotting | `idc-index` |
+| Reading pixel data (pydicom, SimpleITK) | `idc-index` + local files |
+| DICOMweb, BigQuery, direct S3/GCS, Parquet | `idc-index` and the relevant reference guide |
+| Digital pathology tiling and annotation workflows | `idc-index` + `digital_pathology_guide.md` |
+| Reproducible scripts a user will re-run | `idc-index` (a script outlives the session) |
+
+Two rules resolve the overlap:
+
+- **Prefer the server for discovery.** It is hosted against a current IDC release, so it does
+  not depend on the `idc-index` version pinned in `SKILL.md`.
+- **Prefer `idc-index` when the result must become a Python object.** Round-tripping a
+  DataFrame through tool output wastes context and loses types.
+
+## Handing off from the server to `idc-index`
+
+The boundary artifact is a list of `SeriesInstanceUID` values.
+
+```python
+# UIDs obtained from the MCP server's build_cohort / run_sql output
+series_uids = [
+    "1.3.6.1.4.1.14519.5.2.1.7009.2403.334240657131972136850343327463",
+    # ...
+]
+
+from idc_index import IDCClient
+client = IDCClient()
+
+# Confirm size before downloading — the server reports size_TB, but re-check locally
+sizes = client.sql_query(f"""
+    SELECT COUNT(*) AS series, SUM(series_size_MB)/1000 AS size_GB
+    FROM index
+    WHERE SeriesInstanceUID IN ({','.join(f"'{u}'" for u in series_uids)})
+""")
+print(sizes)
+
+client.download_from_selection(
+    downloadDir="./data",
+    seriesInstanceUID=series_uids,       # a list, not a DataFrame
+    dirTemplate="%collection_id/%PatientID/%Modality",
+)
+```
+
+Run `python scripts/check_version.py` before the first `idc-index` call in a session, even if
+discovery happened server-side — the two components version independently.
+
+`get_cohort_urls` also returns ready-made `idc` CLI commands. Those are the better handoff
+when the user wants a shell command they can re-run outside the session; see
+`references/cli_guide.md`.
+
+Going the other direction, `idc-index` results are already local, so there is rarely a reason
+to send them back to the server.
+
+## Version authority
+
+When the server is present, it is the authority on the IDC data version: call
+`get_idc_version` rather than quoting the `idc-data-version` value in the `SKILL.md`
+frontmatter, which records the release the skill was last verified against.
+
+If the server and a locally installed `idc-index` report different versions, say so and name
+both. The mismatch is real — the hosted server tracks IDC releases independently of the user's
+installed package — and it changes which answers about "what's new" are correct.
+
+## Host-specific notes
+
+Everything above is portable. The items below are not, and apply only to specific agent
+environments.
+
+### Claude Code
+
+- **Tool naming.** MCP tools are exposed as `mcp__<server>__<tool>`, where `<server>` is the
+  configured server name with every character outside `A-Za-z0-9_-` replaced by `_`. A CLI
+  install named `idc` yields `mcp__idc__build_cohort`; a claude.ai connector named
+  `IDC MCP prod` yields `mcp__claude_ai_IDC_MCP_prod__build_cohort`.
+- **Enumerating resources.** `ListMcpResourcesTool` returns each resource with a `server`
+  field, which is how to find the `idc://guide` resource and the owning server name in one
+  call.
+- **Adding the server.**
+  `claude mcp add --transport http idc https://api.imaging.datacommons.cancer.gov/mcp`
+- **Permission rules.** Allow rules need a literal, glob-free server segment: `mcp__idc__*`
+  works, `mcp__*` does not. Connector installs need their own
+  `mcp__claude_ai_<name>__*` rule, so the rule differs by install path.
+- **Detecting via the CLI does not work.** `claude mcp list` reads only file-based
+  configuration (`~/.claude.json`, `.mcp.json`). It reports "No MCP servers configured" for a
+  claude.ai connector that is connected and working in the same session, so it cannot be used
+  as a presence check.
+
+### Other hosts
+
+Any agent that supports MCP over streamable HTTP can use the server. Consult that agent's
+documentation for how servers are registered and how tool names are namespaced; the endpoint
+URL and the absence of authentication are all the configuration it needs.

--- a/references/parquet_access_guide.md
+++ b/references/parquet_access_guide.md
@@ -1,6 +1,6 @@
 # Direct Parquet Access Guide for IDC
 
-**Tested with:** idc-index-data 23.10.1, DuckDB 1.x
+**Tested with:** idc-index-data 24.2.2 (IDC data version v24), DuckDB 1.5
 
 All idc-index metadata tables are published as Parquet files to a public GCS bucket with unrestricted CORS access. This enables metadata queries with DuckDB or pandas without installing idc-index — useful for quick exploration or environments where pip install is unavailable.
 

--- a/references/sql_patterns.md
+++ b/references/sql_patterns.md
@@ -1,6 +1,6 @@
 # SQL Query Patterns for IDC
 
-**Tested with:** idc-index 0.12.3 (IDC data version v24)
+**Tested with:** idc-index 0.12.5 (IDC data version v24)
 
 Quick reference for common SQL query patterns when working with IDC data. For detailed examples with context, see the "Core Capabilities" section in the main SKILL.md.
 

--- a/references/use_cases.md
+++ b/references/use_cases.md
@@ -1,6 +1,6 @@
 # Common Use Cases for IDC
 
-**Tested with:** idc-index 0.12.1 (IDC data version v24)
+**Tested with:** idc-index 0.12.5 (IDC data version v24)
 
 This guide provides complete end-to-end workflow examples for common IDC use cases. Each use case demonstrates the full workflow from query to download with best practices.
 

--- a/scripts/check_version.py
+++ b/scripts/check_version.py
@@ -3,24 +3,39 @@
 
 Run FIRST at the start of an IDC session:  python scripts/check_version.py
 
-- Installs the pinned, author-vetted minimum idc-index if it is missing or
-  below MIN_VERSION (does NOT auto-install newer releases).
+- Verifies that idc-index is installed and at least MIN_VERSION. It never
+  installs or upgrades anything itself: if the requirement is not met it prints
+  the exact command to run and exits non-zero, leaving the choice of Python
+  environment to the caller.
 - Notifies (only) when a newer idc-index (PyPI) or skill release (GitHub) is
   available. Network checks are best-effort and silently skipped offline.
 
 Keep MIN_VERSION and SKILL_VERSION in sync with the SKILL.md frontmatter.
 """
-import subprocess
+import re
 import sys
 
-MIN_VERSION = "0.12.3"   # keep in sync with metadata.idc-index in SKILL.md
-SKILL_VERSION = "1.6.5"  # keep in sync with metadata.version in SKILL.md
+MIN_VERSION = "0.12.5"   # keep in sync with metadata.idc-index in SKILL.md
+SKILL_VERSION = "1.7.0"  # keep in sync with metadata.version in SKILL.md
 REPO = "ImagingDataCommons/imaging-data-commons-skill"
+
+_LEADING_DIGITS = re.compile(r"\d+")
 
 
 def parse_version(v):
-    """Numeric tuple for comparison (string comparison misorders multi-digit parts)."""
-    return tuple(int(x) for x in v.lstrip("v").split(".")[:3])
+    """Numeric 3-tuple for comparison (string comparison misorders multi-digit parts).
+
+    Tolerates pre-release and suffixed tags by taking the leading digits of each
+    component: "0.13.0rc1" and "v1.7.0-beta" parse as (0, 13, 0) and (1, 7, 0)
+    rather than raising. A pre-release therefore compares equal to its base
+    release, which keeps the update notices conservative instead of advertising
+    unreleased versions.
+    """
+    parts = []
+    for part in v.lstrip("v").split(".")[:3]:
+        match = _LEADING_DIGITS.match(part)
+        parts.append(int(match.group()) if match else 0)
+    return tuple(parts + [0] * (3 - len(parts)))
 
 
 def fetch_json(url, *keys):
@@ -36,32 +51,32 @@ def fetch_json(url, *keys):
         return None
 
 
-def _pip_install(spec):
-    subprocess.run(
-        ["pip3", "install", "--upgrade", "--break-system-packages", spec],
-        check=True,
-    )
+def print_install_instructions(spec):
+    """Print how to install `spec` — this script never modifies the environment."""
+    print(f"\nInstall the vetted version with:\n\n    {sys.executable} -m pip install '{spec}'\n")
+    print("Use a virtual environment where you can; on an externally managed system Python")
+    print("(PEP 668) pip refuses to install until you use a virtual environment or `--user`.")
+    print("Re-run this script once the install finishes.")
 
 
-def ensure_minimum():
-    """Install the pinned minimum idc-index if missing or below MIN_VERSION.
+def check_minimum():
+    """Check the installed idc-index against MIN_VERSION.
 
-    Returns the installed version string, or None if a fresh install/upgrade
-    happened and the Python process must be restarted to load it.
+    Returns the installed version string, or None if idc-index is missing or
+    older than MIN_VERSION — in which case install instructions are printed and
+    the caller should not proceed until they have been followed.
     """
     try:
         import idc_index
     except ImportError:
-        print(f"Installing idc-index {MIN_VERSION}...")
-        _pip_install(f"idc-index=={MIN_VERSION}")
-        print("Installed. Restart Python to use it.")
+        print(f"idc-index is not installed; this skill requires {MIN_VERSION} or newer.")
+        print_install_instructions(f"idc-index=={MIN_VERSION}")
         return None
 
     installed = idc_index.__version__
     if parse_version(installed) < parse_version(MIN_VERSION):
-        print(f"Upgrading idc-index {installed} -> {MIN_VERSION}...")
-        _pip_install(f"idc-index=={MIN_VERSION}")
-        print("Upgraded. Restart Python to use it.")
+        print(f"idc-index {installed} is below the pinned minimum {MIN_VERSION}.")
+        print_install_instructions(f"idc-index=={MIN_VERSION}")
         return None
 
     print(f"idc-index {installed} meets pinned minimum ({MIN_VERSION})")
@@ -73,7 +88,8 @@ def notify_updates(installed):
     if installed:
         pkg = fetch_json("https://pypi.org/pypi/idc-index/json", "info", "version")
         if pkg and parse_version(pkg) > parse_version(installed):
-            print(f"ℹ️ idc-index {pkg} available — to update: pip install --upgrade idc-index")
+            print(f"ℹ️ idc-index {pkg} available — to update: "
+                  f"{sys.executable} -m pip install --upgrade idc-index")
 
     tag = fetch_json(f"https://api.github.com/repos/{REPO}/releases/latest", "tag_name")
     if tag and parse_version(tag) > parse_version(SKILL_VERSION):
@@ -82,7 +98,10 @@ def notify_updates(installed):
 
 
 def main():
-    notify_updates(ensure_minimum())
+    """Exit 0 when the pinned minimum is installed, 1 when the caller must install it."""
+    installed = check_minimum()
+    notify_updates(installed)
+    return 0 if installed else 1
 
 
 if __name__ == "__main__":

--- a/tests/requirements-test.txt
+++ b/tests/requirements-test.txt
@@ -1,4 +1,4 @@
-idc-index==0.12.3
+idc-index==0.12.5
 pandas
 pytest
 pytest-timeout

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,0 +1,181 @@
+"""
+Contract tests for the hosted IDC MCP server documented in SKILL.md and
+references/mcp_guide.md.
+
+The skill identifies the server by its `idc://guide` resource and by a fingerprint of
+IDC-specific tool names. Those names are a contract with a service that versions
+independently of this repository, so they can go stale silently. These tests read the
+expectations out of the documentation and check them against the live server.
+
+The server is at beta (3.0.0b2) and its tool set may still move. A drift failure here means
+the docs need updating, not that the skill is broken — the skill falls back to idc-index
+whenever identification fails.
+
+Network tests skip (not fail) when the server is unreachable, so an outage does not turn CI
+red. Tests that only compare documentation files run offline.
+"""
+
+import json
+import os
+import re
+import urllib.error
+import urllib.request
+
+import pytest
+
+_ROOT = os.path.join(os.path.dirname(__file__), "..")
+_SKILL_MD = os.path.join(_ROOT, "SKILL.md")
+_MCP_GUIDE = os.path.join(_ROOT, "references", "mcp_guide.md")
+_USAGE_MD = os.path.join(_ROOT, "USAGE.md")
+
+MCP_URL = "https://api.imaging.datacommons.cancer.gov/mcp"
+
+# Names generic enough that another MCP server could plausibly expose them. The skill must
+# never rely on these to identify IDC; see "Identifying the server" in mcp_guide.md.
+GENERIC_TOOL_NAMES = {"run_sql", "get_stats", "list_tables", "get_citations"}
+
+
+def _read(path):
+    with open(path, encoding="utf-8") as fh:
+        return fh.read()
+
+
+def _section(text, heading):
+    """Return the body of a Markdown section, up to the next same-or-higher heading."""
+    level = heading.split(" ", 1)[0]
+    match = re.search(
+        rf"^{re.escape(heading)}\s*$(.*?)(?=^#{{1,{len(level)}}} |\Z)",
+        text,
+        re.M | re.S,
+    )
+    assert match, f"section {heading!r} not found"
+    return match.group(1)
+
+
+# ---------------------------------------------------------------------------
+# Expectations parsed out of the documentation
+# ---------------------------------------------------------------------------
+
+def documented_fingerprint():
+    """Tool names SKILL.md tells the agent to identify the server by."""
+    body = _section(_read(_SKILL_MD), "## IDC MCP Server")
+    match = re.search(r"three or more of the tool names\s+(.+?)\.\s", body, re.S)
+    assert match, "could not locate the tool-name fingerprint in SKILL.md"
+    return set(re.findall(r"`([a-z_]+)`", match.group(1)))
+
+
+def documented_inventory():
+    """Every tool listed in the mcp_guide.md inventory table."""
+    body = _section(_read(_MCP_GUIDE), "## Tool inventory")
+    names = set()
+    for line in body.splitlines():
+        if line.startswith("|"):
+            names.update(re.findall(r"`([a-z_]+)`", line))
+    assert names, "could not parse the tool inventory table in mcp_guide.md"
+    return names
+
+
+# ---------------------------------------------------------------------------
+# Live server
+# ---------------------------------------------------------------------------
+
+def _rpc(method, timeout=20):
+    """Single JSON-RPC call. The server needs no session handshake and no auth."""
+    payload = {"jsonrpc": "2.0", "id": 1, "method": method}
+    request = urllib.request.Request(
+        MCP_URL,
+        data=json.dumps(payload).encode(),
+        headers={
+            "Content-Type": "application/json",
+            "Accept": "application/json, text/event-stream",
+        },
+    )
+    with urllib.request.urlopen(request, timeout=timeout) as response:
+        body = response.read().decode()
+    # Streamable HTTP may frame the reply as a single SSE event.
+    if body.lstrip().startswith("event:") or body.lstrip().startswith("data:"):
+        body = "\n".join(
+            line[len("data:"):].strip()
+            for line in body.splitlines()
+            if line.startswith("data:")
+        )
+    return json.loads(body)["result"]
+
+
+@pytest.fixture(scope="session")
+def server_tools():
+    try:
+        result = _rpc("tools/list")
+    except (urllib.error.URLError, TimeoutError, OSError) as exc:
+        pytest.skip(f"IDC MCP server unreachable: {exc}")
+    return {tool["name"] for tool in result["tools"]}
+
+
+@pytest.fixture(scope="session")
+def server_resources():
+    try:
+        result = _rpc("resources/list")
+    except (urllib.error.URLError, TimeoutError, OSError) as exc:
+        pytest.skip(f"IDC MCP server unreachable: {exc}")
+    return {resource["uri"] for resource in result["resources"]}
+
+
+# ===========================================================================
+# Documentation-only checks (no network)
+# ===========================================================================
+
+class TestDocumentedContract:
+    """Internal consistency of the MCP guidance across the skill's files."""
+
+    def test_endpoint_url_is_consistent_across_docs(self):
+        for path in (_SKILL_MD, _MCP_GUIDE, _USAGE_MD):
+            urls = set(re.findall(r"https://api\.imaging\.datacommons\.cancer\.gov[\w/.-]*", _read(path)))
+            assert urls == {MCP_URL}, f"{os.path.basename(path)} references {urls or 'no'} MCP URL"
+
+    def test_fingerprint_excludes_generic_tool_names(self):
+        # Guards the design decision in mcp_guide.md: a name another server could also
+        # expose must never become evidence that this is IDC.
+        overlap = documented_fingerprint() & GENERIC_TOOL_NAMES
+        assert not overlap, f"fingerprint in SKILL.md relies on generic tool names: {sorted(overlap)}"
+
+    def test_fingerprint_is_large_enough_for_its_own_threshold(self):
+        # SKILL.md asks for "three or more of" these names.
+        assert len(documented_fingerprint()) >= 3
+
+    def test_fingerprint_is_covered_by_the_inventory(self):
+        missing = documented_fingerprint() - documented_inventory()
+        assert not missing, f"fingerprint names absent from the mcp_guide.md inventory: {sorted(missing)}"
+
+
+# ===========================================================================
+# Live server contract
+# ===========================================================================
+
+class TestLiveServer:
+    """The documented contract still holds against the deployed server."""
+
+    def test_fingerprint_tool_names_still_exist(self, server_tools):
+        missing = documented_fingerprint() - server_tools
+        assert not missing, (
+            f"identification would fail: {sorted(missing)} no longer exist on the server. "
+            f"Update the fingerprint in SKILL.md and references/mcp_guide.md."
+        )
+
+    def test_guide_resource_still_exists(self, server_resources):
+        assert "idc://guide" in server_resources, (
+            "the idc://guide resource is gone; it is the strongest identification signal "
+            "documented in references/mcp_guide.md"
+        )
+
+    def test_documented_tools_still_exist(self, server_tools):
+        missing = documented_inventory() - server_tools
+        assert not missing, (
+            f"mcp_guide.md documents tools the server no longer exposes: {sorted(missing)}"
+        )
+
+    def test_inventory_covers_every_server_tool(self, server_tools):
+        undocumented = server_tools - documented_inventory()
+        assert not undocumented, (
+            f"the server exposes tools missing from the mcp_guide.md inventory table: "
+            f"{sorted(undocumented)}"
+        )

--- a/tests/test_snippets.py
+++ b/tests/test_snippets.py
@@ -2,12 +2,14 @@
 Regression tests for all queries and code snippets documented in the Imaging Data Commons Skill.
 
 Covers: SKILL.md, references/sql_patterns.md, references/index_tables_guide.md,
-        references/clinical_data_guide.md
+        references/clinical_data_guide.md, references/use_cases.md,
+        references/digital_pathology_guide.md, references/parquet_access_guide.md
 
 Excluded (require auth or network I/O beyond metadata):
   - Actual DICOM downloads
   - DICOMweb endpoints
-  - Direct S3/GCS access
+  - Direct S3/GCS access to DICOM objects (the public Parquet metadata
+    artifacts used by parquet_access_guide.md are covered)
   - pydicom / SimpleITK integration (no downloaded files)
 
 BigQuery snippets are covered separately in test_bq_snippets.py (uses bq CLI dry-run).
@@ -17,6 +19,7 @@ import os
 import re
 import sys
 
+import duckdb
 import pandas as pd
 import pytest
 import idc_index
@@ -75,8 +78,32 @@ class TestVersionAndSetup:
         assert check_version.parse_version("0.12.0") > check_version.parse_version("0.9.0")
         assert check_version.parse_version("v1.6.5") == (1, 6, 5)
 
+    def test_parse_version_tolerates_prereleases(self):
+        # A pre-release tag upstream must not crash the startup check.
+        assert check_version.parse_version("0.13.0rc1") == (0, 13, 0)
+        assert check_version.parse_version("v1.7.0-beta") == (1, 7, 0)
+        assert check_version.parse_version("1.7") == (1, 7, 0)
+
     def test_fetch_json_returns_none_when_unreachable(self):
         assert check_version.fetch_json("https://pypi.org/pypi/_no_such_pkg_/json", "info") is None
+
+    def test_check_version_never_installs(self):
+        """The script reports and instructs; it must not mutate the environment.
+
+        Auto-installing into whatever interpreter `pip` happens to resolve to can
+        silently rewrite a user's global site-packages, so installation is left to
+        the caller.
+        """
+        with open(check_version.__file__, encoding="utf-8") as fh:
+            source = fh.read()
+        for forbidden in ("subprocess", "--break-system-packages", "pip3"):
+            assert forbidden not in source, f"check_version.py must not use {forbidden}"
+
+    def test_install_instructions_target_running_interpreter(self, capsys):
+        check_version.print_install_instructions(f"idc-index=={check_version.MIN_VERSION}")
+        out = capsys.readouterr().out
+        assert f"{sys.executable} -m pip install" in out
+        assert check_version.MIN_VERSION in out
 
     def test_script_versions_match_skill_frontmatter(self):
         with open(_SKILL_MD, encoding="utf-8") as fh:
@@ -719,3 +746,432 @@ class TestClinicalDataGuide:
         clinical_patients = set(nlst_canc["dicom_patient_id"].unique())
         overlap = imaging_patients & clinical_patients
         assert len(overlap) > 0
+
+
+# ===========================================================================
+# use_cases.md
+# ===========================================================================
+
+class TestUseCases:
+    """references/use_cases.md – end-to-end workflows.
+
+    Only the selection queries are covered: every use case ends in
+    download_from_selection() or pydicom/SimpleITK processing of downloaded
+    files, both excluded per the module docstring. Use Case 5's query is
+    identical to TestBatchAndManifest::test_batch_filter_query.
+    """
+
+    def test_uc1_nlst_lung_ct_training_set(self, client):
+        df = client.sql_query("""
+            SELECT PatientID, SeriesInstanceUID, SeriesDescription
+            FROM index
+            WHERE collection_id = 'nlst'
+              AND Modality = 'CT'
+              AND BodyPartExamined = 'CHEST'
+              AND license_short_name = 'CC BY 4.0'
+            ORDER BY PatientID
+            LIMIT 100
+        """)
+        assert len(df) == 100
+        assert df["PatientID"].nunique() > 0
+
+    @pytest.fixture(scope="class")
+    def brain_mr_manufacturers(self, client):
+        return client.sql_query("""
+            SELECT Manufacturer, ManufacturerModelName,
+                   COUNT(DISTINCT SeriesInstanceUID) as num_series,
+                   COUNT(DISTINCT PatientID) as num_patients
+            FROM index
+            WHERE Modality = 'MR' AND BodyPartExamined LIKE '%BRAIN%'
+            GROUP BY Manufacturer, ManufacturerModelName
+            HAVING num_series >= 10
+            ORDER BY num_series DESC
+        """)
+
+    def test_uc2_brain_mr_by_manufacturer(self, brain_mr_manufacturers):
+        assert len(brain_mr_manufacturers) > 0
+        assert (brain_mr_manufacturers["num_series"] >= 10).all()
+
+    def test_uc2_sample_per_manufacturer(self, client, brain_mr_manufacturers):
+        # The guide interpolates each row into a follow-up query.
+        row = brain_mr_manufacturers.iloc[0]
+        df = client.sql_query(f"""
+            SELECT SeriesInstanceUID
+            FROM index
+            WHERE Manufacturer = '{row['Manufacturer']}'
+              AND ManufacturerModelName = '{row['ManufacturerModelName']}'
+              AND Modality = 'MR'
+              AND BodyPartExamined LIKE '%BRAIN%'
+            LIMIT 5
+        """)
+        assert len(df) > 0
+
+    def test_uc3_preview_before_download(self, client):
+        df = client.sql_query("""
+            SELECT SeriesInstanceUID, PatientID, SeriesDescription
+            FROM index
+            WHERE collection_id = 'acrin_nsclc_fdg_pet' AND Modality = 'PT'
+            LIMIT 10
+        """)
+        assert len(df) > 0
+        url = client.get_viewer_URL(seriesInstanceUID=df.iloc[0]["SeriesInstanceUID"])
+        assert url.startswith("http")
+
+    def test_uc4_license_aware_selection(self, client):
+        df = client.sql_query("""
+            SELECT SeriesInstanceUID, collection_id, PatientID, Modality
+            FROM index
+            WHERE license_short_name LIKE 'CC BY%'
+              AND license_short_name NOT LIKE '%NC%'
+              AND Modality IN ('CT', 'MR')
+              AND BodyPartExamined IN ('CHEST', 'BRAIN', 'ABDOMEN')
+            LIMIT 200
+        """)
+        assert len(df) > 0
+        assert set(df["Modality"]) <= {"CT", "MR"}
+
+
+# ===========================================================================
+# digital_pathology_guide.md
+# ===========================================================================
+
+class TestDigitalPathologyGuide:
+    """references/digital_pathology_guide.md."""
+
+    def test_sm_metadata_by_collection(self, client_with_all_indices):
+        df = client_with_all_indices.sql_query("""
+            SELECT i.collection_id, COUNT(*) as slides,
+                   MIN(s.min_PixelSpacing_2sf) as min_resolution
+            FROM sm_index s
+            JOIN index i ON s.SeriesInstanceUID = i.SeriesInstanceUID
+            GROUP BY i.collection_id
+            ORDER BY slides DESC
+        """)
+        assert len(df) > 0
+
+    def test_sm_objective_lens_power(self, client_with_all_indices):
+        df = client_with_all_indices.sql_query("""
+            SELECT i.collection_id, i.PatientID, s.ObjectiveLensPower,
+                   s.min_PixelSpacing_2sf
+            FROM sm_index s
+            JOIN index i ON s.SeriesInstanceUID = i.SeriesInstanceUID
+            WHERE s.ObjectiveLensPower >= 40
+            ORDER BY s.min_PixelSpacing_2sf
+            LIMIT 20
+        """)
+        assert len(df) > 0
+
+    def test_sm_staining_array_filter(self, client_with_all_indices):
+        # Specimen preparation columns are arrays – array_to_string() + LIKE.
+        df = client_with_all_indices.sql_query("""
+            SELECT i.PatientID,
+                   s.staining_usingSubstance_CodeMeaning as staining,
+                   s.embeddingMedium_CodeMeaning as embedding,
+                   s.tissueFixative_CodeMeaning as fixative
+            FROM sm_index s
+            JOIN index i ON s.SeriesInstanceUID = i.SeriesInstanceUID
+            WHERE i.collection_id = 'tcga_brca'
+              AND array_to_string(s.staining_usingSubstance_CodeMeaning, ', ')
+                  LIKE '%hematoxylin%'
+            LIMIT 10
+        """)
+        assert len(df) > 0
+
+    def test_sm_embedding_medium_breakdown(self, client_with_all_indices):
+        df = client_with_all_indices.sql_query("""
+            SELECT i.collection_id, s.embeddingMedium_CodeMeaning as embedding,
+                   COUNT(*) as slide_count
+            FROM sm_index s
+            JOIN index i ON s.SeriesInstanceUID = i.SeriesInstanceUID
+            GROUP BY i.collection_id, embedding
+            ORDER BY i.collection_id, slide_count DESC
+        """)
+        assert len(df) > 0
+
+    def test_tissue_type_values(self, client_with_all_indices):
+        df = client_with_all_indices.sql_query("""
+            SELECT s.primaryAnatomicStructureModifier_CodeMeaning as tissue_type,
+                   COUNT(*) as slide_count
+            FROM sm_index s
+            WHERE s.primaryAnatomicStructureModifier_CodeMeaning IS NOT NULL
+            GROUP BY tissue_type
+            ORDER BY slide_count DESC
+        """)
+        assert "Neoplasm, Primary" in set(df["tissue_type"])
+
+    def test_tcga_brca_tissue_breakdown(self, client_with_all_indices):
+        df = client_with_all_indices.sql_query("""
+            SELECT s.primaryAnatomicStructureModifier_CodeMeaning as tissue_type,
+                   COUNT(*) as slide_count,
+                   COUNT(DISTINCT i.PatientID) as patient_count
+            FROM sm_index s
+            JOIN index i ON s.SeriesInstanceUID = i.SeriesInstanceUID
+            WHERE i.collection_id = 'tcga_brca'
+            GROUP BY tissue_type
+            ORDER BY slide_count DESC
+        """)
+        counts = dict(zip(df["tissue_type"], df["slide_count"]))
+        # The guide quotes these counts inline – fails if the data release moves them.
+        assert counts["Neoplasm, Primary"] == 2704
+        assert counts["Normal"] == 399
+
+    def test_tcga_barcode_sample_type(self, client_with_all_indices):
+        df = client_with_all_indices.sql_query("""
+            SELECT SUBSTRING(SPLIT_PART(s.ContainerIdentifier, '-', 4), 1, 2)
+                       as sample_type_code,
+                   s.primaryAnatomicStructureModifier_CodeMeaning as tissue_type,
+                   COUNT(*) as slide_count
+            FROM sm_index s
+            JOIN index i ON s.SeriesInstanceUID = i.SeriesInstanceUID
+            WHERE i.collection_id = 'tcga_brca'
+            GROUP BY sample_type_code, tissue_type
+            ORDER BY sample_type_code
+        """)
+        counts = dict(zip(df["sample_type_code"], df["slide_count"]))
+        # Guide: 01 -> 2704 tumor, 06 -> 8 metastatic (tissue_type NULL), 11 -> 399 normal.
+        assert counts == {"01": 2704, "06": 8, "11": 399}
+
+    def test_ann_series_discovery(self, client_with_all_indices):
+        df = client_with_all_indices.sql_query("""
+            SELECT a.SeriesInstanceUID as ann_series, a.AnnotationCoordinateType,
+                   a.referenced_SeriesInstanceUID as source_series
+            FROM ann_index a
+            LIMIT 10
+        """)
+        assert len(df) > 0
+
+    def test_ann_group_statistics(self, client_with_all_indices):
+        df = client_with_all_indices.sql_query("""
+            SELECT GraphicType, SUM(NumberOfAnnotations) as total_annotations,
+                   COUNT(*) as group_count
+            FROM ann_group_index
+            GROUP BY GraphicType
+            ORDER BY total_annotations DESC
+        """)
+        assert len(df) > 0
+
+    def test_ann_with_source_slide_context(self, client_with_all_indices):
+        df = client_with_all_indices.sql_query("""
+            SELECT i.collection_id, g.GraphicType,
+                   g.AnnotationPropertyType_CodeMeaning, g.AlgorithmName,
+                   g.NumberOfAnnotations
+            FROM ann_group_index g
+            JOIN ann_index a ON g.SeriesInstanceUID = a.SeriesInstanceUID
+            JOIN index i ON a.referenced_SeriesInstanceUID = i.SeriesInstanceUID
+            WHERE g.AlgorithmName IS NOT NULL
+            LIMIT 10
+        """)
+        assert len(df) > 0
+
+    def test_segmentations_on_slide_microscopy(self, client_with_all_indices):
+        df = client_with_all_indices.sql_query("""
+            SELECT seg.SeriesInstanceUID as seg_series, seg.AlgorithmName,
+                   seg.total_segments, src.collection_id,
+                   src.Modality as source_modality
+            FROM seg_index seg
+            JOIN index src ON seg.segmented_SeriesInstanceUID = src.SeriesInstanceUID
+            WHERE src.Modality = 'SM'
+            LIMIT 20
+        """)
+        assert len(df) > 0
+        assert set(df["source_modality"]) == {"SM"}
+
+    def test_pathology_analysis_results(self, client_with_all_indices):
+        df = client_with_all_indices.sql_query("""
+            SELECT ar.analysis_result_id, ar.analysis_result_title, ar.modalities,
+                   ar.subjects, ar.collections
+            FROM analysis_results_index ar
+            WHERE ar.modalities LIKE '%ANN%' OR ar.modalities LIKE '%SEG%'
+            ORDER BY ar.subjects DESC
+        """)
+        assert len(df) > 0
+
+    def test_derived_data_for_collection(self, client_with_all_indices):
+        df = client_with_all_indices.sql_query("""
+            SELECT i.analysis_result_id, i.PatientID,
+                   a.referenced_SeriesInstanceUID as source_slide,
+                   g.AnnotationGroupLabel, g.NumberOfAnnotations, g.AlgorithmName
+            FROM ann_group_index g
+            JOIN ann_index a ON g.SeriesInstanceUID = a.SeriesInstanceUID
+            JOIN index i ON a.SeriesInstanceUID = i.SeriesInstanceUID
+            WHERE i.collection_id = 'tcga_brca'
+            LIMIT 10
+        """)
+        assert len(df) > 0
+
+    def test_annotation_group_label_filter(self, client_with_all_indices):
+        df = client_with_all_indices.sql_query("""
+            SELECT g.SeriesInstanceUID, g.AnnotationGroupLabel, g.GraphicType,
+                   g.NumberOfAnnotations, g.AlgorithmName
+            FROM ann_group_index g
+            WHERE LOWER(g.AnnotationGroupLabel) LIKE '%blast%'
+            ORDER BY g.NumberOfAnnotations DESC
+        """)
+        assert len(df) > 0
+
+    def test_annotation_label_with_collection_context(self, client_with_all_indices):
+        # The guide uses 'your_collection_id'/'keyword' placeholders here.
+        df = client_with_all_indices.sql_query("""
+            SELECT i.collection_id, g.AnnotationGroupLabel, g.GraphicType,
+                   g.NumberOfAnnotations, g.AnnotationPropertyType_CodeMeaning
+            FROM ann_group_index g
+            JOIN ann_index a ON g.SeriesInstanceUID = a.SeriesInstanceUID
+            JOIN index i ON a.SeriesInstanceUID = i.SeriesInstanceUID
+            WHERE i.collection_id = 'tcga_brca'
+              AND LOWER(g.AnnotationGroupLabel) LIKE '%nucle%'
+            ORDER BY g.NumberOfAnnotations DESC
+        """)
+        assert len(df) > 0
+
+    def test_sm_ann_cross_reference(self, client_with_all_indices):
+        df = client_with_all_indices.sql_query("""
+            SELECT i.collection_id, s.ObjectiveLensPower, g.AnnotationGroupLabel,
+                   g.NumberOfAnnotations, g.GraphicType
+            FROM ann_group_index g
+            JOIN ann_index a ON g.SeriesInstanceUID = a.SeriesInstanceUID
+            JOIN sm_index s ON a.referenced_SeriesInstanceUID = s.SeriesInstanceUID
+            JOIN index i ON a.SeriesInstanceUID = i.SeriesInstanceUID
+            WHERE i.collection_id = 'tcga_brca'
+            ORDER BY g.NumberOfAnnotations DESC
+            LIMIT 10
+        """)
+        assert len(df) > 0
+
+    def test_sm_join_pattern(self, client_with_all_indices):
+        df = client_with_all_indices.sql_query("""
+            SELECT i.collection_id, i.PatientID, s.ObjectiveLensPower,
+                   s.min_PixelSpacing_2sf
+            FROM index i
+            JOIN sm_index s ON i.SeriesInstanceUID = s.SeriesInstanceUID
+            LIMIT 10
+        """)
+        assert len(df) > 0
+
+    def test_ann_join_pattern(self, client_with_all_indices):
+        df = client_with_all_indices.sql_query("""
+            SELECT i.collection_id, g.AnnotationGroupLabel, g.GraphicType,
+                   g.NumberOfAnnotations,
+                   a.referenced_SeriesInstanceUID as source_series
+            FROM ann_group_index g
+            JOIN ann_index a ON g.SeriesInstanceUID = a.SeriesInstanceUID
+            JOIN index i ON a.SeriesInstanceUID = i.SeriesInstanceUID
+            LIMIT 10
+        """)
+        assert len(df) > 0
+
+
+# ===========================================================================
+# parquet_access_guide.md – DuckDB against the public Parquet artifacts
+# ===========================================================================
+
+PARQUET_BASE = (
+    "https://storage.googleapis.com/idc-index-data-artifacts/current/release_artifacts"
+)
+
+
+class TestParquetAccessGuide:
+    """references/parquet_access_guide.md (idc-index not used – DuckDB over HTTPS)."""
+
+    def test_listed_files_exist(self):
+        import urllib.request
+        for name in [
+            "idc_index", "volume_geometry_index", "rtstruct_index", "seg_index",
+            "sm_index", "contrast_index", "ann_index", "ann_group_index",
+            "collections_index", "analysis_results_index", "clinical_index",
+            "ct_index", "mr_index", "pt_index", "prior_versions_index",
+        ]:
+            url = f"{PARQUET_BASE}/{name}.parquet"
+            request = urllib.request.Request(url, method="HEAD")
+            with urllib.request.urlopen(request, timeout=30) as response:
+                assert response.status == 200, f"{name}.parquet missing at {url}"
+
+    def test_current_resolves_to_installed_data_release(self):
+        # The guide states current/ always resolves to the latest data release.
+        import idc_index_data
+        pinned = (
+            "https://storage.googleapis.com/idc-index-data-artifacts/"
+            f"{idc_index_data.__version__}/release_artifacts"
+        )
+        current_rows = duckdb.sql(
+            f"SELECT COUNT(*) FROM read_parquet('{PARQUET_BASE}/idc_index.parquet')"
+        ).fetchone()[0]
+        pinned_rows = duckdb.sql(
+            f"SELECT COUNT(*) FROM read_parquet('{pinned}/idc_index.parquet')"
+        ).fetchone()[0]
+        assert current_rows == pinned_rows
+
+    def test_modality_counts(self):
+        df = duckdb.sql(f"""
+            SELECT Modality, COUNT(*) as series_count,
+                   ROUND(SUM(series_size_MB)/1000, 1) as size_GB
+            FROM read_parquet('{PARQUET_BASE}/idc_index.parquet')
+            GROUP BY Modality
+            ORDER BY series_count DESC
+        """).df()
+        assert len(df) > 0
+
+    def test_ct_collections_by_size(self):
+        df = duckdb.sql(f"""
+            SELECT collection_id,
+                   COUNT(DISTINCT PatientID) as patients,
+                   COUNT(*) as series,
+                   ROUND(SUM(series_size_MB)/1000, 1) as size_GB
+            FROM read_parquet('{PARQUET_BASE}/idc_index.parquet')
+            WHERE Modality = 'CT'
+            GROUP BY collection_id
+            ORDER BY size_GB DESC
+            LIMIT 10
+        """).df()
+        assert len(df) == 10
+
+    def test_volume_geometry_join(self):
+        df = duckdb.sql(f"""
+            SELECT i.collection_id, i.SeriesInstanceUID, i.BodyPartExamined,
+                   v.obliquity_degrees, v.regularly_spaced_3d_volume
+            FROM read_parquet('{PARQUET_BASE}/idc_index.parquet') i
+            JOIN read_parquet('{PARQUET_BASE}/volume_geometry_index.parquet') v
+                ON i.SeriesInstanceUID = v.SeriesInstanceUID
+            WHERE i.Modality = 'CT'
+              AND v.regularly_spaced_3d_volume = TRUE
+            LIMIT 10
+        """).df()
+        assert len(df) == 10
+
+    def test_volume_geometry_fraction_per_collection(self):
+        df = duckdb.sql(f"""
+            SELECT i.collection_id, i.Modality, COUNT(*) as total,
+                   SUM(CASE WHEN v.regularly_spaced_3d_volume THEN 1 ELSE 0 END) as valid_3d
+            FROM read_parquet('{PARQUET_BASE}/idc_index.parquet') i
+            JOIN read_parquet('{PARQUET_BASE}/volume_geometry_index.parquet') v
+                ON i.SeriesInstanceUID = v.SeriesInstanceUID
+            WHERE i.Modality IN ('CT', 'MR', 'PT')
+            GROUP BY i.collection_id, i.Modality
+            ORDER BY total DESC
+            LIMIT 10
+        """).df()
+        assert len(df) == 10
+
+    def test_rtstruct_roi_details(self):
+        df = duckdb.sql(f"""
+            SELECT i.collection_id, i.SeriesInstanceUID, r.total_rois, r.ROINames,
+                   r.RTROIInterpretedTypes, r.referenced_SeriesInstanceUID
+            FROM read_parquet('{PARQUET_BASE}/idc_index.parquet') i
+            JOIN read_parquet('{PARQUET_BASE}/rtstruct_index.parquet') r
+                ON i.SeriesInstanceUID = r.SeriesInstanceUID
+            WHERE i.Modality = 'RTSTRUCT'
+            LIMIT 5
+        """).df()
+        assert len(df) == 5
+
+    def test_rtstruct_collections(self):
+        df = duckdb.sql(f"""
+            SELECT i.collection_id, COUNT(*) as rtstruct_series,
+                   ROUND(AVG(r.total_rois), 1) as avg_rois_per_struct
+            FROM read_parquet('{PARQUET_BASE}/idc_index.parquet') i
+            JOIN read_parquet('{PARQUET_BASE}/rtstruct_index.parquet') r
+                ON i.SeriesInstanceUID = r.SeriesInstanceUID
+            GROUP BY i.collection_id
+            ORDER BY rtstruct_series DESC
+            LIMIT 10
+        """).df()
+        assert len(df) == 10


### PR DESCRIPTION
Two related bodies of work, released together as **1.7.0**: teaching the skill to coexist with IDC's hosted MCP server, and responding to the `check_version.py` review on [K-Dense-AI/scientific-agent-skills#158](https://github.com/K-Dense-AI/scientific-agent-skills/pull/158#pullrequestreview-4780191940).

## IDC MCP server coordination

IDC now runs a hosted MCP server at `https://api.imaging.datacommons.cancer.gov/mcp` (streamable HTTP, no authentication). A session that already has it connected shouldn't be told to `pip install idc-index` and re-derive what the server can answer directly.

- New "IDC MCP Server" section in `SKILL.md` plus `references/mcp_guide.md`: how to recognize the server, how to divide work between it and `idc-index`, and how to hand off `SeriesInstanceUID`s for download.
- The routing decision sits in the `SKILL.md` Overview next to "Primary tool", so it's read *before* the `idc-index` setup rather than discovered after. `idc-index` remains the primary, always-available path and the version check stays unconditional.
- Identification is deliberately conservative: the `idc://guide` MCP resource, or a fingerprint of three or more IDC-specific tool names. Generic names like `run_sql` are explicitly **not** evidence, and anything ambiguous falls back to `idc-index`.
- New `USAGE.md` section with the endpoint and a Claude Code registration example.

`tests/test_mcp_server.py` parses the documented fingerprint and tool inventory back out of `SKILL.md` / `references/mcp_guide.md` and checks them against the live server, so the docs can't drift silently as the beta server evolves. Network tests skip rather than fail when the server is unreachable; the offline checks guard URL consistency and keep generic tool names out of the fingerprint.

## `check_version.py` no longer installs anything

The script previously ran `pip3 install --upgrade --break-system-packages`. That bypassed the PEP 668 guard on externally managed interpreters and — combined with the `pandas<=2.2.4` cap in idc-index ≤ 0.12.4 — could silently downgrade a system-wide pandas 3.x as a side effect of a version *check*. It also invoked whatever `pip3` resolved to on `PATH`, which is not necessarily the running interpreter's pip, so the install could land in a different environment than the one that failed to import `idc_index`.

It now prints the exact `pip install` command for the running interpreter and exits non-zero, leaving the choice of environment to the user. `SKILL.md` documents the new behavior.

Also fixed: `parse_version` no longer raises on pre-release or suffixed tags (`0.13.0rc1`, `v1.7.0-beta`), so an upstream pre-release can't crash the startup check. Pre-releases compare equal to their base release, which keeps update notices conservative.

## idc-index 0.12.5

The pinned minimum moves from 0.12.3 to 0.12.5, which relaxes the dependency to `pandas>=2.2.2,<4`. Installing the skill's minimum no longer perturbs a pandas 3.x environment — verified against pandas 3.0.5. IDC data version remains v24.

## Snippet test coverage and stale headers

`use_cases.md`, `digital_pathology_guide.md`, and `parquet_access_guide.md` each carried a `Tested with:` header but had **no tests behind it**, so those headers couldn't be refreshed honestly. This adds 31 tests (98 total, up from 67):

- **`TestUseCases`** — the selection query from each use case, plus the viewer-URL preview step. Downloads and the pydicom/SimpleITK steps stay excluded per the module docstring.
- **`TestDigitalPathologyGuide`** — all 18 slide microscopy / annotation / segmentation queries. Two assert the TCGA-BRCA counts quoted inline in the guide (2704 primary / 399 normal; barcode sample types 01/06/11), so a data release that moves them fails CI instead of quietly making the prose wrong.
- **`TestParquetAccessGuide`** — the DuckDB-over-HTTPS queries, plus checks that every Parquet file listed in the guide exists under `current/` and that `current/` resolves to the installed `idc-index-data` release.

All snippets were re-run against idc-index 0.12.5 / idc-index-data 24.2.2 *before* the headers were updated. `bigquery_guide.md` was reworded rather than version-bumped — its SQL doesn't use idc-index, so it now names the dataset it was actually validated against (`bigquery-public-data.idc_current`, via `bq query --dry_run`).

The `VERSION = "23.10.1"` pinning example in `parquet_access_guide.md` is left as-is on purpose: it demonstrates pinning to an *older* release, and that URL still resolves.

## Why 1.7.0 and not 1.6.6

The MCP support adds a new routing surface, and dropping the auto-install changes documented startup behavior for anyone who relied on it. Neither is a patch-level change.

## Testing

Run locally against idc-index 0.12.5 / idc-index-data 24.2.2 / pandas 3.0.5:

| Suite | Result |
|---|---|
| `tests/test_snippets.py` | 98 passed (5m39s) |
| `tests/test_bq_snippets.py` | 33 passed (2m11s) — real `bq query --dry_run` against `idc_current` |
| `tests/test_mcp_server.py` | 8 passed |

The CI cache key and the `test-snippets.yml` path filter were updated to match.

## Follow-up

Downstream [K-Dense-AI/scientific-agent-skills#158](https://github.com/K-Dense-AI/scientific-agent-skills/pull/158) vendors v1.6.5 and is waiting on the `check_version.py` fix; it can sync to 1.7.0 once this lands and is tagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
