### PR TITLE
Route read-only metadata to the REST API instead of installing idc-index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,24 +5,27 @@ All notable changes to the Imaging Data Commons Skill are documented in this fil
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [1.8.0] - 2026-08-07
+## [1.8.0] - 2026-08-10
 
 ### Added
 
-- `references/rest_api_guide.md` — IDC's hosted REST API at `https://api.imaging.datacommons.cancer.gov/v3` (no authentication): query surfaces, endpoint reference, `terms` / `ranges` filter syntax, SQL guardrails, clinical tables, manifests, licenses, citations. Verified endpoint by endpoint against API 3.0.0b2 / IDC v24
-- Warning that filter endpoints ignore unrecognized top-level keys, so a mis-shaped body silently selects **all of IDC** with HTTP 200: `counts` and `licenses` take the filter object directly, while `manifest`, `manifest.txt`, and `citations` wrap it in `filters`
-- Measured request limits: `/sql` `max_rows` 5000 default / 10000 cap, `cohort/manifest` `page_size` 100 / 5000, clinical rows 5000 / 100000, attribute values 100 / 10000; `cohort/manifest.txt` is the one uncapped surface
+- `references/rest_api_guide.md` — IDC's hosted REST API at `https://api.imaging.datacommons.cancer.gov/v3` (no authentication): query surfaces, endpoint reference, `terms` / `ranges` filter syntax, SQL guardrails, clinical tables, manifests, licenses, citations. Verified endpoint by endpoint against API 3.0.0b3 / IDC v24
+- One filter body shape on every filtered endpoint — the filter object goes under `filters`. Misuse is refused rather than ignored (`422` for a bare filter or unknown key, `400` for an unfiltered manifest), and responses echo `filters_applied` and `warnings`, so a zero count with no warnings means the filter matched nothing ([IDC-REST-MCP#44](https://github.com/ImagingDataCommons/IDC-REST-MCP/pull/44))
+- Measured request limits: `/sql` 5000 / 10000 rows and a 30 s timeout, `cohort/manifest` `page_size` 100 / 5000, `manifest.txt` 100000 series, clinical rows 5000 / 100000, attribute values 100 / 10000. No rate limit or quota
 - How to check the API against a local `idc-index` via `idc_index_data_version`, and how to read a mismatch: the major is the IDC data release (`24.x.y` serves `v24`), so a differing major means different series, while a differing minor or patch is an index build of the same release
 - Workaround for a major mismatch: `idc-index` silently skips manifest rows its own index does not list, so upgrade it or transfer directly from the bucket with `s5cmd --no-sign-request`. Also summarized in `SKILL.md`, since the failure is silent
 - "Use v3 only" guidance in `SKILL.md` and the guide: V1 and V2 are superseded and scheduled for shutdown, so V1/V2 examples should be ported rather than extended
 - REST API entries in `SKILL.md` (Data Access Options, Quick Navigation, Tool Selection Guide, network access) and `USAGE.md` (setup section, allowed domains, guide listings)
-- `tests/test_rest_api.py`: contract tests that check the guide's endpoint list, attribute lists, and limits against the live API, skipping when it is unreachable. Added to `test-snippets.yml`
+- `tests/test_rest_api.py`: contract tests for the guide's endpoints, attributes, limits, and filter contract, checked against the live API and skipping when unreachable. `IDC_API_BASE` points them at a staging deployment. Added to `test-snippets.yml`
 
 - `references/licensing_and_citation.md` — license semantics (CC BY vs CC BY-NC shares, custom terms, the most-restrictive-term rule for mixed cohorts) and citation generation. Written access-path-neutral: `idc-index`, `POST /v3/licenses` / `POST /v3/citations`, and the `get_licenses` / `get_citations` MCP tools side by side, since neither task is tied to Python
 - `tests/test_structure.py` — file-only contract tests, added to `test-snippets.yml` ahead of the slower suites: a 500-line budget for `SKILL.md`, resolution of every guide it names, no orphan guides in `references/`, and assertions pinning the always-loaded content listed below. No network or `idc-index` install needed
 
 ### Changed
 
+- Access-path selection is task-based rather than one fixed default. With no MCP server and no `idc-index` installed, read-only metadata (counts, attribute values, SQL under 10000 rows, licenses, citations, viewer URLs) goes to the REST API instead of paying a ~77 MB install; `idc-index` remains the path for downloads, pandas, pixel data, and larger results, and the only one that moves image bytes. `SKILL.md` opens with that four-branch gate, and its frontmatter description no longer names `idc-index`
+- `SKILL.md` and the troubleshooting entries defer to `scripts/check_version.py` for install and upgrade commands rather than printing a bare `pip install`, which could target a different interpreter than the one running and ignores the pinned version
+- Positioned direct Parquet access after the REST API: it still needs `pip install duckdb` and does not publish the per-collection clinical tables, so it is for version pinning and results past the REST row cap
 - Reduced `SKILL.md` from 722 to under 500 lines, holding the budget in CI rather than leaving it to downstream registries to re-split after every sync. Content moved into the topical guide that already owns each subject rather than into a new catch-all file:
   - Discovery and SQL examples (overall-scale query, per-collection breakdown, `collections_index` / `analysis_results_index` queries) → `references/sql_patterns.md`
   - Full index-table inventory with row granularity → `references/index_tables_guide.md`, which also gained the "which table contains column X" search pattern; `SKILL.md` keeps a five-row table-family map

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: imaging-data-commons
-description: Query and download public cancer imaging data from NCI Imaging Data Commons using idc-index. Invoke for any question about IDC collections, cancer imaging datasets, DICOM data access, radiology (CT, MR, PET) or pathology AI training sets, metadata queries, visualization, or license checks — even when the user doesn't explicitly mention "IDC". No authentication required.
+description: Query and download public cancer imaging data from NCI Imaging Data Commons. Invoke for any question about IDC collections, cancer imaging datasets, DICOM data access, radiology (CT, MR, PET) or pathology AI training sets, metadata queries, visualization, or license checks — even when the user doesn't explicitly mention "IDC". No authentication required.
 license: This skill is provided under the MIT License. IDC data itself has individual licensing (mostly CC-BY, some CC-NC) that must be respected when using the data.
 metadata:
     version: 1.8.0
@@ -14,32 +14,36 @@ metadata:
 
 ## Overview
 
-Use the `idc-index` Python package to query and download public cancer imaging data from the National Cancer Institute Imaging Data Commons (IDC). No authentication required for data access.
+Query and download public cancer imaging data from the National Cancer Institute Imaging Data Commons (IDC). No authentication required for data access.
 
-**Expected network access:** `idc-index` queries a local DuckDB index (no network for metadata). File downloads use public GCS (`storage.googleapis.com`) and AWS S3 (`s3.amazonaws.com`) — no authentication required. The optional IDC REST API and MCP server (`api.imaging.datacommons.cancer.gov`) also need no authentication. DICOMweb access uses either the public IDC proxy (`proxy.imaging.datacommons.cancer.gov`, no auth) or the Google Cloud Healthcare API (`healthcare.googleapis.com`, requires GCP authentication). Optional BigQuery queries (`bigquery.googleapis.com`) also require GCP authentication. No credentials or environment variables are accessed by this skill.
+**Expected network access:** IDC metadata is reachable three ways — a local DuckDB index shipped with the `idc-index` Python package (no network), or the hosted IDC service over MCP or REST (`api.imaging.datacommons.cancer.gov`, no authentication). File downloads use public GCS (`storage.googleapis.com`) and AWS S3 (`s3.amazonaws.com`) — no authentication required. DICOMweb access uses either the public IDC proxy (`proxy.imaging.datacommons.cancer.gov`, no auth) or the Google Cloud Healthcare API (`healthcare.googleapis.com`, requires GCP authentication). Optional BigQuery queries (`bigquery.googleapis.com`) also require GCP authentication. No credentials or environment variables are accessed by this skill.
 
-**Current IDC Data Version: v24** (always verify with `IDCClient().get_idc_version()`)
+**Current IDC Data Version: v24** (always verify — see *Best Practices*)
 
-**Primary tool:** `idc-index` ([GitHub](https://github.com/imagingdatacommons/idc-index)) — the
-default path, always available.
+**Choose the access path first.** There is no single default: the cheapest correct path depends
+on the session and the task.
 
-**First, check your session:** if it already has the hosted IDC MCP server, route discovery and
-metadata there and skip the setup below — see *IDC MCP Server*. Return here for downloads and
-local analysis. Otherwise continue straight through.
+1. **Session already has the IDC MCP server?** Route discovery and metadata there — see *IDC
+   MCP Server*.
+2. **Otherwise, is `idc-index` installed?** Run `python scripts/check_version.py`. If it passes,
+   use `idc-index` for everything.
+3. **Not installed, and the task is read-only metadata** — counts, attribute values, collection
+   lookups, SQL under 10 000 rows, licenses, citations, viewer URLs? **Use the REST API over
+   `curl`; do not install anything.** Installing costs ~77 MB of packaged index data plus
+   pandas, pyarrow, and duckdb, which a metadata question does not need. See *Data Access
+   Options*.
+4. **Not installed, and the task needs more than metadata** — downloading files, pandas or
+   plotting, pydicom/SimpleITK, pathology tiling, results past 10 000 rows, or a version-pinned
+   script the user re-runs? Install `idc-index`: `check_version.py` exits non-zero and prints
+   the exact `pip install` command for the running interpreter. Prefer a virtual environment,
+   then restart Python.
 
-**CRITICAL - run this FIRST**, before any IDC query that uses `idc-index`:
+`idc-index` ([GitHub](https://github.com/imagingdatacommons/idc-index)) is still the most
+capable path and the only one that moves image bytes; the rule is just not to pay for it before
+the task calls for it. `check_version.py` never installs anything itself — it also flags a newer
+`idc-index` or skill release when one exists.
 
-```bash
-python scripts/check_version.py
-```
-
-It checks the installed `idc-index` against the pinned minimum and prints a notice when a newer
-`idc-index` release (which may carry a newer IDC data version) or a newer skill version is
-available, with the link to update. It never installs or upgrades anything itself: if the
-pinned minimum is missing it exits non-zero and prints the exact `pip install` command for the
-running interpreter — run that, preferring a virtual environment, then restart Python.
-
-**Verify the IDC data version before answering anything about IDC content:**
+**Setup for the `idc-index` path:**
 
 ```python
 from idc_index import IDCClient
@@ -49,12 +53,10 @@ client = IDCClient()
 print(f"IDC data version: {client.get_idc_version()}")
 ```
 
-For current data scale — collections, patients, studies, series, instances, total TB — run the
-summary query in `references/sql_patterns.md`.
-
 **Core workflow:** query metadata with `client.sql_query()` → download with
-`client.download_from_selection()` → visualize with `client.get_viewer_URL()`. Examples
-throughout this document assume `client = IDCClient()` from the setup above.
+`client.download_from_selection()` → visualize with `client.get_viewer_URL()`. Python examples
+below assume this `client`; *Data Access Options* has the REST equivalents. For current data
+scale, run the summary query in `references/sql_patterns.md` or `GET /v3/stats`.
 
 ## IDC MCP Server
 
@@ -78,12 +80,11 @@ analysis, DICOMweb, BigQuery, digital pathology tiling, and reproducible scripts
 passing SeriesInstanceUIDs from the server to `client.download_from_selection(...)`, and run
 `scripts/check_version.py` at that point.
 
-**If it is not available**, use `idc-index` below — the default, fully capable path. Mention
-the endpoint once only if the task would clearly benefit (repeated interactive discovery, or
-no local Python), and let the user decide how to connect it. Do not change their
-configuration, and do not repeat the suggestion. The same service is also reachable without
-any MCP configuration as a REST API at `https://api.imaging.datacommons.cancer.gov/v3` — see
-*Data Access Options* and `references/rest_api_guide.md`.
+**If it is not available**, the identical service is reachable with no configuration as a REST
+API at `https://api.imaging.datacommons.cancer.gov/v3` — use it for read-only metadata rather
+than installing `idc-index`, per the routing gate in *Overview*. Suggest connecting the MCP
+server at most once, only for repeated interactive discovery, and never change the user's
+configuration yourself.
 
 See `references/mcp_guide.md` for the tool inventory, handoff patterns, and per-host notes.
 
@@ -124,9 +125,7 @@ troubleshooting.
 IDC adds two grouping levels above the standard DICOM hierarchy (Patient → Study → Series → Instance):
 
 - **collection_id**: Groups patients by disease, modality, or research focus (e.g., `tcga_luad`, `nlst`). A patient belongs to exactly one collection.
-- **analysis_result_id**: Identifies derived objects (segmentations, annotations, radiomics features) across one or more original collections.
-
-Use `collection_id` to find original imaging data, may include annotations deposited along with the images; use `analysis_result_id` to find AI-generated or expert annotations.
+- **analysis_result_id**: Identifies derived objects (segmentations, annotations, radiomics features) across one or more original collections. Use it to find AI-generated or expert annotations, while `collection_id` finds original imaging data (which may itself include deposited annotations).
 
 **Key identifiers for queries:**
 | Identifier | Scope | Use for |
@@ -138,14 +137,9 @@ Use `collection_id` to find original imaging data, may include annotations depos
 
 ## Index Tables
 
-The `idc-index` package provides multiple metadata index tables, accessible via SQL or as pandas DataFrames.
+The `idc-index` package provides multiple metadata index tables, accessible via SQL or as pandas DataFrames. The REST API exposes the same tables through `GET /tables` and `POST /sql`.
 
-**Complete index table documentation:** Use https://idc-index.readthedocs.io/en/latest/indices_reference.html for quick check of available tables and columns without executing any code.
-
-**Important:** Use `client.indices_overview` to get current table descriptions and column schemas. This is the authoritative source for available columns and their types — always query it when writing SQL or exploring data structure.
-
-`client.indices_overview` also answers "which table contains column X" — see
-`references/index_tables_guide.md` for that search pattern and full schema discovery.
+**Important:** `client.indices_overview` is the authoritative source for current table descriptions, available columns, and their types — query it when writing SQL or exploring data structure. It also answers "which table contains column X"; see `references/index_tables_guide.md` for that search pattern and full schema discovery.
 
 ### Available Tables
 
@@ -197,10 +191,10 @@ joining clinical data with imaging.
 
 | Method | Auth | Best For | Reference |
 |--------|------|----------|-----------|
-| `idc-index` | No | Queries and downloads — the default | This document |
+| `idc-index` | No | Downloads, pandas analysis, unbounded queries — the most capable path | This document |
 | IDC MCP server | No | Discovery, cohort building, metadata when the session already has it | `mcp_guide.md` |
-| IDC REST API | No | HTTP from any language or shell; no Python install | `rest_api_guide.md` |
-| Direct Parquet (GCS) | No | Queries without installing idc-index; always latest data | `parquet_access_guide.md` |
+| IDC REST API | No | Metadata with no install, from any language or shell — the default when `idc-index` is absent | `rest_api_guide.md` |
+| Direct Parquet (GCS) | No | Version-pinned queries, or results past the REST row cap | `parquet_access_guide.md` |
 | Cloud storage (S3/GCS) | No | Direct file access, bulk transfer, custom pipelines | `cloud_storage_guide.md` |
 | DICOMweb via IDC proxy | No | Tool and PACS integration; daily quota, so testing and moderate use | `dicomweb_guide.md` |
 | DICOMweb via Google Healthcare | Yes (GCP) | The same DICOMweb API at production volume, without the proxy quota | `dicomweb_guide.md` |
@@ -212,59 +206,71 @@ browser-based exploration, manual cohort selection, and download. Unlike every o
 has no programmatic interface, so point a user there to browse or click through data
 themselves; never use it as a step in a script or workflow.
 
+**REST API — the no-install metadata path**
+
+`https://api.imaging.datacommons.cancer.gov/v3`, no authentication: discovery, cohort counts and
+manifests, read-only SQL, clinical tables, viewer URLs, licenses, citations. It is the same
+service as the MCP server over plain HTTP, so it needs no configuration. It never moves image
+bytes — switch to `idc-index` to download, to get a DataFrame, or for results past 10 000 rows.
+
+```bash
+B=https://api.imaging.datacommons.cancer.gov/v3
+curl -s $B/version   # idc_version, idc_index_data_version, api_version
+curl -s $B/stats     # collections, patients, studies, series, instances, size_TB
+curl -s "$B/attributes/Modality/values?limit=5"   # real filter values, with counts
+curl -s $B/sql -H 'content-type: application/json' \
+  -d '{"sql":"SELECT collection_id, COUNT(*) n FROM index GROUP BY 1 ORDER BY n DESC LIMIT 3"}'
+curl -s $B/cohort/counts -H 'content-type: application/json' \
+  -d '{"filters":{"terms":{"collection_id":["rider_pilot"]}}}'
+```
+
+**The filter object always goes under `filters`** — on `cohort/counts`, `cohort/manifest`,
+`cohort/manifest.txt`, `licenses`, and `citations` alike. A bare filter or an unrecognized key is
+a 422 naming the fix; an unfiltered series-enumerating request is a 400, not the whole archive.
+Every filtered response echoes `filters_applied` and `warnings` — read them, because they name
+any predicate the server dropped. A zero count with empty `warnings` therefore means the filter
+matched nothing, not that a value was miscased; miscasing produces a warning that says so.
+
+`POST /sql` takes one read-only `SELECT`/`WITH` over the tables `idc-index` exposes plus
+`clinical.<table>`; `max_rows` defaults to 5 000, caps at 10 000, and `truncated` flags clipping.
+`GET /attributes` lists the 19 filterable attributes — clinical values, segmented anatomy, and
+acquisition parameters are not among them and need SQL. There is no rate limit or quota. **Use
+v3 only:** V1 and V2 are superseded and scheduled for shutdown, so port any `/v1/`- or
+`Modality_btw`-style example a user brings rather than extending it.
+
+Both sides build on `idc-index-data`, so compare the API's `idc_index_data_version` against local
+`idc_index_data.__version__` before mixing them: the **major is the IDC data release** (`24.x.y`
+serves `v24`), so differing minor/patch means the series are identical. If the API is a whole
+release ahead, `idc-index` **cannot download the extra series** — it silently skips what its own
+index does not list — so either upgrade it (run `scripts/check_version.py` for the right command)
+or transfer directly from the bucket with `s5cmd --no-sign-request`.
+
+See `references/rest_api_guide.md` for the endpoint reference, filter grounding, limits, and the
+manifest-based download flow.
+
 **Cloud storage organization**
 
-All DICOM files live in public buckets mirrored between AWS S3 and GCS, organized by CRDC
-UUIDs (not DICOM UIDs) to support versioning: `idc-open-data` (>90% of data),
-`idc-open-data-two` / `idc-open-idc1` (collections with potential head scans), and
-`idc-open-data-cr` / `idc-open-cr` (~4%, commercial use restricted, CC BY-NC). Files are stored
-as `<crdc_series_uuid>/<crdc_instance_uuid>.dcm`; access is free (no egress fees) via AWS CLI,
-gsutil, or s5cmd with anonymous access. Use the `series_aws_url` column for S3 URLs; GCS uses
-the same path structure. See `references/cloud_storage_guide.md`.
+All DICOM files live in public buckets mirrored between AWS S3 and GCS, organized by CRDC UUIDs
+(not DICOM UIDs) to support versioning, as `<crdc_series_uuid>/<crdc_instance_uuid>.dcm`. Access
+is free (no egress fees) via AWS CLI, gsutil, or s5cmd with anonymous access; use the
+`series_aws_url` column for S3 URLs. Note that `idc-open-data-cr` / `idc-open-cr` (~4% of data)
+is commercial-use restricted (CC BY-NC). See `references/cloud_storage_guide.md` for the full
+bucket list and UUID mapping.
 
 **DICOMweb access**
 
-IDC data is available via DICOMweb (Google Cloud Healthcare API implementation) for PACS
-integration and DICOMweb-compatible tools: a public proxy (no auth, daily quota) for testing
-and moderate queries, or Google Healthcare (GCP auth) for production volumes. See
-`references/dicomweb_guide.md` for endpoints, supported operations, and code examples.
-
-**REST API**
-
-IDC hosts a REST API at `https://api.imaging.datacommons.cancer.gov/v3` (no authentication)
-covering discovery, cohort counts and manifests, read-only SQL, clinical tables, viewer URLs,
-licenses, and citations. It is the same service as the MCP server, over plain HTTP. Reach for
-it when there is no Python available, when the client is another language, or when the user
-wants shell commands they can re-run; use `idc-index` when the result must become a Python
-object or files must be downloaded.
-
-**Use v3 only.** The V1 and V2 APIs are superseded and scheduled for shutdown — never write
-new code against them, and port any V1/V2 examples a user brings (recognizable by a `/v1/` or
-`/v2/` path, or filter suffixes like `Modality_btw`) to v3 instead of extending them.
-
-```bash
-curl -s https://api.imaging.datacommons.cancer.gov/v3/version
-```
-
-Both sides are built on `idc-index-data` and report its version, so check them against each
-other before mixing them: the API's `idc_index_data_version` (from `/v3/version`) vs local
-`idc_index_data.__version__`. The **major is the IDC data release** (`24.x.y` serves `v24`);
-minor and patch are index builds of that same release, so if only those differ the series are
-identical. If the API is a whole release ahead, `idc-index` **cannot download the extra
-series** — it resolves every URL against its own index and silently skips what it does not
-list — so either `pip install --upgrade idc-index` or transfer directly from the bucket with
-`s5cmd --no-sign-request`.
-
-See `references/rest_api_guide.md` for the endpoint reference, filter syntax, limits, the
-version-skew download workaround, and the body-shape pitfall that makes a mis-shaped filter
-silently return all of IDC.
+IDC data is available via DICOMweb (Google Cloud Healthcare API) for PACS integration and
+DICOMweb-compatible tools: a public proxy (no auth, daily quota) for testing and moderate
+queries, or Google Healthcare (GCP auth) for production volumes. See
+`references/dicomweb_guide.md`.
 
 **Direct Parquet access**
 
-All idc-index metadata tables are published as Parquet files to a public GCS bucket
-(`idc-index-data-artifacts`) with unrestricted CORS, enabling DuckDB or pandas queries without
-installing idc-index — including cross-table joins and queries against `volume_geometry_index`
-and `rtstruct_index`. See `references/parquet_access_guide.md` for URL patterns and examples.
+The idc-index metadata tables are also published as Parquet on a public GCS bucket
+(`idc-index-data-artifacts`), queryable with DuckDB or pandas. This needs `pip install duckdb`
+and cannot reach the per-collection clinical tables, so prefer REST `/sql` for ad-hoc metadata;
+choose Parquet to pin a data version or for results past the REST row cap. See
+`references/parquet_access_guide.md`.
 
 ## Core Capabilities
 
@@ -287,7 +293,9 @@ print(modalities)
 ```
 
 The same pattern works for any filter column, optionally narrowed by another —
-`BodyPartExamined` within a `Modality`, `Manufacturer`, `collection_id`.
+`BodyPartExamined` within a `Modality`, `Manufacturer`, `collection_id`. On the REST path this
+grounding is a single call — `GET /attributes/{attr}/values` returns values with counts — and the
+cohort endpoints report a miscased value in `warnings` rather than as an empty result.
 
 Two indices carry curated collection-level metadata the primary `index` does not, both
 requiring `client.fetch_index(...)` first: `collections_index` (cancer types, tumor locations,
@@ -414,10 +422,10 @@ or the `get_licenses` and `get_citations` MCP tools. See
 `references/licensing_and_citation.md` for the full license inventory, all three routes, the
 citation formats (APA, BibTeX, CSL JSON, RDF Turtle), and what to include when publishing.
 
-### 5. Reaching past `idc-index`
+### 5. Reaching past the index
 
-**Default choice:** use `idc-index` for most tasks (no auth, easy API, batch downloads).
-*Data Access Options* above is the full routing table.
+Pick the access path with the routing gate in *Overview*; *Data Access Options* above is the
+full routing table.
 
 Before reaching for BigQuery (which needs a billing-enabled GCP account), check whether a
 specialized index table already has the column you want: search `client.indices_overview`,
@@ -429,19 +437,17 @@ idc-index equivalent.
 ## Best Practices
 
 - **Check schema before writing queries** — Use `client.get_index_schema('index')` (reads cached metadata, no SQL executed) or `client.indices_overview` to see all available columns and their descriptions. The version-tracking columns `series_init_idc_version` and `series_revised_idc_version` in the main `index` table directly answer "what's new / when was this added" questions without touching `prior_versions_index`.
-- **Never use web search for IDC data content questions** - Always query the idc-index directly using `client.sql_query()`. Web sources (release notes, blog posts, documentation pages) are frequently out of date and will produce incorrect answers. The local DuckDB index is the authoritative source; use it even when web search is available.
-- **Verify IDC version before generating responses** - Always call `client.get_idc_version()` at the start of a session to confirm you're using the expected data version (currently v24). If using an older version, recommend `pip install --upgrade idc-index`
+- **Never use web search for IDC data content questions** - Always query the IDC index directly, via `client.sql_query()` locally or `POST /v3/sql` over HTTP. Web sources (release notes, blog posts, documentation pages) are frequently out of date and will produce incorrect answers. The index is the authoritative source; use it even when web search is available.
+- **Verify the IDC data version at the start of a session** - `client.get_idc_version()`, `GET /v3/version`, or the MCP `get_idc_version` tool, depending on the path in use (currently v24). For a stale local index, run `scripts/check_version.py` and use the upgrade command it prints
 - **Check licenses and generate citations** - Query `license_short_name` and respect CC BY vs CC BY-NC terms; use `citations_from_selection()` to produce citations from `source_DOI` for publications
-- **Start with small queries** - Use `LIMIT` clause when exploring to avoid long downloads and understand data structure
-- **Organize downloads with dirTemplate** - Use meaningful directory structures like `%collection_id/%PatientID/%Modality`
-- **Estimate size first** - Check collection size before downloading - some collection sizes are in terabytes!
-- **Save manifests** - Always save query results with Series UIDs for reproducibility and data provenance
+- **Explore small, then commit** - Use `LIMIT` (or a low `max_rows`) while exploring, and check collection size before downloading — some collections are terabytes. See `references/cli_guide.md`
+- **Keep downloads reproducible** - Organize with `dirTemplate` (e.g. `%collection_id/%PatientID/%Modality`) and save the Series UIDs or manifest behind any dataset you build
 
 ## Troubleshooting
 
 **Issue: `ModuleNotFoundError: No module named 'idc_index'`**
 - **Cause:** idc-index package not installed
-- **Solution:** Install with `pip install --upgrade idc-index`; for data analysis also install `pip install pandas numpy pydicom` (tested with pandas>=1.5, numpy>=1.23, pydicom>=2.3)
+- **Solution:** If the task is read-only metadata, do not install it — use the REST API instead (*Data Access Options*). Otherwise run `scripts/check_version.py` and use the install command it prints, which targets the running interpreter and pins the vetted version. For data analysis also add pandas, numpy, and pydicom (tested with pandas>=1.5, numpy>=1.23, pydicom>=2.3)
 
 **Issue: Download fails with connection timeout**
 - **Cause:** Network instability or large download size
@@ -459,14 +465,8 @@ idc-index equivalent.
 
 **Issue: Column not found in `index` table (e.g., `SliceThickness`, `PixelSpacing`, `KVP`, `EchoTime`, `InjectedDose`)**
 - **Cause:** The `index` table contains series-level metadata only; modality-specific acquisition and reconstruction parameters live in dedicated tables (`ct_index`, `mr_index`, `pt_index`)
-- **Solution:** Search `client.indices_overview` to find the right table, then fetch and join on `SeriesInstanceUID`:
+- **Solution:** Search `client.indices_overview` for the column to find its table — the loop is under *Finding which table contains a column* in `references/index_tables_guide.md` — then fetch and join on `SeriesInstanceUID`:
   ```python
-  target = "SliceThickness"
-  for table_name, info in client.indices_overview.items():
-      if any(c["name"] == target for c in info["schema"]["columns"]):
-          print(f"Found in: {table_name}")
-  # → Found in: ct_index
-
   client.fetch_index("ct_index")
   result = client.sql_query("""
       SELECT i.SeriesInstanceUID, i.Modality, c.SliceThickness, c.KVP, c.PixelSpacing_row_mm

--- a/USAGE.md
+++ b/USAGE.md
@@ -32,7 +32,7 @@ This gives Claude the complete skill with all the reference guides in one upload
      * `*.github.com` and `*.githubusercontent.com`: used to access source code and release artifacts
      * `*.googleapis.com`: used to fetch IDC data from Google Storage buckets
      * `*.s3.amazonaws.com`: used to fetch IDC data from Amazon S3 buckets
-     * `api.imaging.datacommons.cancer.gov`: used for the IDC REST API and MCP server (optional — only if you want the skill to query IDC over HTTP)
+     * `api.imaging.datacommons.cancer.gov`: the IDC REST API and MCP server — recommended, since it lets the skill answer metadata questions over HTTP without installing anything
 
 <img width="899" height="648" alt="image" src="https://github.com/user-attachments/assets/5bcb2d6f-9b9b-4c9e-955f-839cb4a98ca3" />
 
@@ -152,9 +152,10 @@ produces `mcp__claude_ai_<name>__*`. Allow rules require a literal server segmen
 ## IDC REST API (No Setup Required)
 
 The same service is also a plain REST API at `https://api.imaging.datacommons.cancer.gov/v3`,
-with no authentication and nothing to register. The skill uses it when an assistant has no
-local Python, when the client is another language, or when the user wants shell commands they
-can re-run:
+with no authentication and nothing to register. The skill prefers it for read-only metadata
+whenever `idc-index` is not already installed — answering a counts or attribute question does not
+justify a ~77 MB package install — and also uses it when the client is another language or the
+user wants shell commands they can re-run:
 
 ```bash
 curl -s https://api.imaging.datacommons.cancer.gov/v3/version

--- a/references/mcp_guide.md
+++ b/references/mcp_guide.md
@@ -42,12 +42,14 @@ anything. The trust anchor is the URL the user configured plus TLS, which is est
 the server is added, not when the skill runs. That is sufficient for routing: the check only
 has to distinguish IDC from the user's other installed servers.
 
-**Fail soft.** If identification is ambiguous, or a tool call fails, fall back to `idc-index`
-rather than reporting an error. Tool names may change as the server matures.
+**Fail soft.** If identification is ambiguous, or a tool call fails, fall back rather than
+reporting an error — to the REST API (`rest_api_guide.md`) for read-only metadata, which is the
+same service with no configuration, or to `idc-index` when it is already installed or the task
+needs downloads or local analysis. Tool names may change as the server matures.
 
 ## Tool inventory
 
-Verified against server version `3.0.0b2`. Treat this as a snapshot, not a contract — call
+Verified against server version `3.0.0b3`. Treat this as a snapshot, not a contract — call
 the server's own listing rather than assuming this list is current.
 
 | Group | Tools |
@@ -66,6 +68,13 @@ those instructions for tool sequencing (ground with `list_attributes` /
 `get_attribute_values` before filtering; check `list_tables` before writing SQL). Do not
 re-derive that workflow from `SKILL.md` — the two would drift apart on the server's next
 release.
+
+**Cohort results report their own filters.** `build_cohort` and `get_cohort_urls` require at
+least one filter predicate and fail cleanly without one, rather than returning the whole archive;
+results echo the filters actually applied along with warnings for any predicate that was dropped
+or any value whose casing did not match. Read those warnings before reporting a count — a zero
+with no warning means the filter matched nothing, which is a real answer. Same contract as the
+REST endpoints they wrap; see `rest_api_guide.md`.
 
 ## Division of labor
 

--- a/references/parquet_access_guide.md
+++ b/references/parquet_access_guide.md
@@ -2,18 +2,21 @@
 
 **Tested with:** idc-index-data 24.2.2 (IDC data version v24), DuckDB 1.5
 
-All idc-index metadata tables are published as Parquet files to a public GCS bucket with unrestricted CORS access. This enables metadata queries with DuckDB or pandas without installing idc-index — useful for quick exploration or environments where pip install is unavailable.
+All idc-index metadata tables are published as Parquet files to a public GCS bucket with unrestricted CORS access. This enables metadata queries with DuckDB or pandas without installing idc-index.
 
 **Limitation:** download helpers (`download_from_selection()`), viewer URLs (`get_viewer_URL()`), and citation generation require the idc-index client and are not available from raw Parquet files.
+
+**This is not the first no-install option to reach for.** It still needs `pip install duckdb`, and the per-collection clinical tables are not published here — only the `clinical_index` dictionary. For ad-hoc metadata with nothing installed, the REST API (`rest_api_guide.md`) needs no install at all and reaches `clinical.<table>` through `POST /sql`.
 
 ## When to Use This Guide
 
 Load this guide when you need to:
-- Query IDC metadata without installing idc-index
-- Run ad-hoc DuckDB queries against the latest index files
-- Access `volume_geometry_index` or `rtstruct_index` for geometry validation or RT structure queries
+- Pin queries to a specific IDC data version (see *Pinning to a Specific Version* below) rather than whatever the hosted API currently serves
+- Return more rows than the REST `/sql` ceiling of 10 000
+- Run heavy or repeated local DuckDB analysis without driving the hosted API
+- Query IDC metadata where DuckDB is available but idc-index is not
 
-For full API access (downloads, viewer, citations), use idc-index as documented in the main SKILL.md.
+For downloads, viewer URLs, and citations, use idc-index as documented in the main SKILL.md.
 
 ## URL Pattern
 

--- a/references/rest_api_guide.md
+++ b/references/rest_api_guide.md
@@ -1,6 +1,6 @@
 # IDC REST API Guide
 
-**Tested with:** API `3.0.0b2` (build `968e137`), IDC data version v24, `idc_index_data_version` 24.2.2
+**Tested with:** API `3.0.0b3` (build `0640860`), IDC data version v24, `idc_index_data_version` 24.2.2
 
 IDC operates a hosted REST API that exposes discovery, cohort building, metadata SQL, and
 download manifests over plain HTTP. No authentication, account, or credentials are required —
@@ -29,14 +29,17 @@ storage to the client.
 | Situation | Use |
 |-----------|-----|
 | Session already has the hosted MCP server | MCP tools (`mcp_guide.md`) — same data, no HTTP plumbing |
-| Local Python, results feed pandas / downloads | `idc-index` (`SKILL.md`) |
+| `idc-index` already installed, results feed pandas / downloads | `idc-index` (`SKILL.md`) |
+| `idc-index` **not** installed and the task is read-only metadata | This REST API — do not install to answer a metadata question |
 | No Python, or a non-Python client, or shell commands the user re-runs | This REST API |
 | Installed `idc-index` is a whole IDC data release behind and cannot be upgraded here | REST API for the query, **direct bucket transfer** may be needed for the download — `idc-index` cannot fetch what its index does not list |
 
 Being hosted, the API always serves a current IDC release — but so does an up-to-date
 `idc-index`. "I want the newest data" is not on its own a reason to prefer the API: the normal
-fix for a stale local index is `pip install --upgrade idc-index`. Reach for the API on version
-grounds only when upgrading is not an option in that environment.
+fix for a stale local index is to upgrade it. Reach for the API on version grounds only when
+upgrading is not an option in that environment. Avoiding the install *is* a reason, though: the
+packaged index data is ~77 MB before pandas, pyarrow, and duckdb, which a metadata question does
+not need.
 
 ## Endpoint and Versioning
 
@@ -54,7 +57,7 @@ running build rather than assuming the values in this guide:
 
 ```bash
 curl -s https://api.imaging.datacommons.cancer.gov/v3/version
-# {"idc_version":"v24","idc_index_data_version":"24.2.2","api_version":"3.0.0b2","build":"968e137"}
+# {"idc_version":"v24","idc_index_data_version":"24.2.2","api_version":"3.0.0b3","build":"0640860"}
 ```
 
 `idc_version` is the IDC data release the API serves and is the authority when the API is in
@@ -179,7 +182,8 @@ All paths are relative to `https://api.imaging.datacommons.cancer.gov/v3`.
 ## Filter Syntax
 
 Cohort filters are shared by `cohort/counts`, `cohort/manifest`, `cohort/manifest.txt`,
-`licenses`, and `citations`. They have two parts:
+`licenses`, and `citations`. **The filter object always goes under a `filters` key**, on every one
+of them. It has two parts:
 
 - **`terms`** — `{attribute: [values]}` for equality/membership. Values are **OR**'d within an
   attribute and **AND**'d across attributes.
@@ -188,12 +192,14 @@ Cohort filters are shared by `cohort/counts`, `cohort/manifest`, `cohort/manifes
 
 ```json
 {
-  "terms": {"Modality": ["CT"], "collection_id": ["nlst"]},
-  "ranges": {"instanceCount": {"gte": 100, "lte": 200}}
+  "filters": {
+    "terms": {"Modality": ["CT"], "collection_id": ["nlst"]},
+    "ranges": {"instanceCount": {"gte": 100, "lte": 200}}
+  }
 }
 ```
 
-Filters operate only on the `index` table's filterable attributes — 19 of them as of `3.0.0b2`:
+Filters operate only on the `index` table's filterable attributes — 19 of them as of `3.0.0b3`:
 
 | Kind | Attributes |
 |------|------------|
@@ -208,37 +214,40 @@ Anything outside this list — clinical values, segmented anatomy, per-modality 
 parameters — is not filterable here; use the SQL surface instead.
 
 **Ground values before filtering.** Call `GET /attributes` for what is filterable and whether
-it is a term or a range, then `GET /attributes/{attr}/values` for real values and their
-casing. Do not guess: an unknown *attribute* is a 400, but a misspelled *value* is not —
-`{"Modality": ["mr"]}` returns all-zero counts with HTTP 200, which reads like "no such data"
-rather than "wrong casing".
+it is a term or a range, then `GET /attributes/{attr}/values` for real values and their casing —
+values are matched case-sensitively.
 
-### An empty filter is not an error — check the body shape
+### The server reports what it filtered on
 
-Filter endpoints ignore unrecognized top-level keys and treat a missing filter as *no filter*,
-so a mis-shaped body silently selects **all of IDC** with HTTP 200:
+Every filtered response echoes `filters_applied` and `warnings`, and misuse is refused rather
+than ignored. Together these make a result self-describing, so you do not have to sanity-check a
+count against a number you happen to remember.
+
+| Mistake | Response |
+|---------|----------|
+| Bare filter object, no `filters` key | `422` naming the correct shape |
+| Unrecognized key at any depth (`term` for `terms`, a range bound spelled `min`) | `422` pointing at the key |
+| Unknown filter attribute, or a range attribute used as a term | `400` naming the discovery call |
+| Unfiltered `cohort/manifest` or `manifest.txt` | `400` — it will not enumerate the whole archive |
+| Unfiltered `cohort/counts` or `licenses` | `200` plus an explicit "ENTIRE IDC archive" warning |
+| A predicate that constrains nothing (`{"collection_id": []}`, `{"instanceCount": {}}`) | `200`, and `warnings` names the ignored predicate |
+| Miscased value (`mr` for `MR`) | `200`, zero counts, and a warning naming the casing that exists |
 
 ```bash
-# WRONG — `filters` is not a field of the counts body, so it is ignored
 curl -s $B/cohort/counts -H 'content-type: application/json' \
   -d '{"filters": {"terms": {"collection_id": ["rider_pilot"]}}}'
-# {"patients":85362,"studies":166740,"series":1032911,...,"size_TB":99.267}   ← all of IDC
-
-# RIGHT — counts takes the filter object directly
-curl -s $B/cohort/counts -H 'content-type: application/json' \
-  -d '{"terms": {"collection_id": ["rider_pilot"]}}'
-# {"patients":8,"studies":154,"series":774,"instances":21111,"size_TB":0.011}
+# {"patients":8,"studies":154,"series":774,"instances":21111,"size_TB":0.011,
+#  "filters_applied":{"terms":{"collection_id":["rider_pilot"]},"ranges":{}},"warnings":[]}
 ```
 
-The same mistake in reverse — sending a bare filter object to `manifest`, `manifest.txt`, or
-`citations`, which expect it under `filters` — likewise returns the unfiltered result. Sanity-
-check every filtered response against a count you expect: a `size_TB` near 99 or a `series`
-count near 1,032,911 means the filter was dropped, not that the cohort is huge.
+**Read `warnings` before reporting any count.** A zero count with `warnings: []` means the filter
+applied and matched nothing — that is a real answer. A zero count *with* a casing warning means
+the filter was wrong. And `filters_applied` covers the case no shape check can: a request
+carrying one good predicate plus one that constrains nothing returns a perfectly plausible
+number, and only `warnings` reveals the dropped half.
 
-| Body shape | Endpoints |
-|------------|-----------|
-| Filter object directly: `{"terms": …, "ranges": …}` | `cohort/counts`, `licenses` |
-| Filter wrapped: `{"filters": {…}, …}` | `cohort/manifest`, `cohort/manifest.txt`, `citations` |
+`cohort/manifest.txt` returns `text/plain` and so cannot carry these fields; there the
+required-predicate `400` does the same job, appending the ignored-predicate reason to its message.
 
 ## Worked Examples
 
@@ -263,14 +272,12 @@ Check size first — `counts` is cheap and answers "is this download sane?":
 ```bash
 curl -s $B/cohort/counts \
   -H 'content-type: application/json' \
-  -d '{"terms": {"Modality": ["MR"], "BodyPartExamined": ["BREAST"]}}'
-# {"patients":3718,"studies":5689,"series":47986,"instances":6493262,"size_TB":2.421}
+  -d '{"filters": {"terms": {"Modality": ["MR"], "BodyPartExamined": ["BREAST"]}}}'
+# {"patients":3718,"studies":5689,"series":47986,"instances":6493262,"size_TB":2.421,
+#  "filters_applied":{...},"warnings":[]}
 ```
 
-Then request a page of series plus the download payload. Note the shape difference: `counts`
-and `licenses` take the filter object **directly**, while `manifest`, `manifest.txt`, and
-`citations` **wrap** it in a `filters` key. Getting this wrong does not raise an error — see
-*An empty filter is not an error* above.
+Then request a page of series plus the download payload — same filter, same `filters` key.
 
 ```bash
 curl -s $B/cohort/manifest \
@@ -299,7 +306,7 @@ curl -s "$B/viewer-url?study_instance_uid=1.3.6.1.4.1.14519.5.2.1.7695.4164.1299
 
 curl -s $B/licenses \
   -H 'content-type: application/json' \
-  -d '{"terms": {"collection_id": ["rider_pilot"]}}'
+  -d '{"filters": {"terms": {"collection_id": ["rider_pilot"]}}}'
 
 curl -s $B/citations \
   -H 'content-type: application/json' \
@@ -338,9 +345,11 @@ print(get("/version")["idc_version"])
 modalities = {v["value"] for v in get("/attributes/Modality/values", limit=1000)["values"]}
 assert "MR" in modalities
 
-# 3. Size the cohort, then page through it
+# 3. Size the cohort, then page through it — the filter always goes under `filters`
 filters = {"terms": {"collection_id": ["rider_pilot"], "Modality": ["CT"]}}
-print(post("/cohort/counts", filters))
+counts = post("/cohort/counts", {"filters": filters})
+assert not counts["warnings"], counts["warnings"]   # nothing was silently dropped
+print(counts)
 
 manifest = post("/cohort/manifest", {"filters": filters, "page": 0, "page_size": 100})
 uids = [row["SeriesInstanceUID"] for row in manifest["series"]]
@@ -357,7 +366,7 @@ reason before retrying.
 Ground the schema with `GET /tables` and `GET /tables/{table}` — do not guess table or column
 names.
 
-**Guardrails** (verified against `3.0.0b2`):
+**Guardrails** (verified against `3.0.0b3`):
 
 - Only single read-only `SELECT` / `WITH … SELECT` statements are accepted. Anything else is
   rejected with `{"error": {"code": "invalid_query", "message": "Only read-only SELECT (or WITH ... SELECT) statements are allowed."}}` and HTTP 400.
@@ -505,7 +514,7 @@ IDC is ~99 TB across 176 collections. Always report `series` and `size_TB` from
 
 ## Limits, Defaults, and Errors
 
-Measured against `3.0.0b2`. Values above a cap are silently clamped — the response echoes the
+Measured against `3.0.0b3`. Values above a cap are silently clamped — the response echoes the
 value actually used (`max_rows`, `page_size`), so read it back rather than assuming the request
 was honored.
 
@@ -517,30 +526,38 @@ was honored.
 | `POST /cohort/manifest` | `page_size` | 100 | 5000 |
 | `POST /cohort/manifest` | `page` | 0 | — |
 | `POST /cohort/manifest` | `include_rows` | `true` | — |
-| `POST /cohort/manifest.txt` | `limit` | unlimited | — |
+| `POST /cohort/manifest.txt` | `limit` | 100000 | — |
 | `POST /cohort/manifest.txt` | `source` | `aws` | — |
 | `POST /citations` | `citation_format` | `apa` | — |
 
-`cohort/manifest.txt` is the surface that is *not* row-capped: it returned all 774 lines for
-`rider_pilot` with no `limit` set. That is why bulk series belong there rather than in a `/sql`
-dump.
+`cohort/manifest.txt` is the surface that is not *row*-capped the way `/sql` is — it returned all
+774 lines for `rider_pilot` with no `limit` set, and enumerates up to 100 000 series. That is why
+bulk series belong there rather than in a `/sql` dump.
+
+There is **no per-caller rate limit or quota** and no `429`. What is bounded is the individual
+request: a 30 s SQL statement timeout, 4 GB query memory, and the caps above. A burst is absorbed
+by autoscaling and surfaces as slower responses or a `503` — back off and retry rather than
+treating it as permanent. For sustained heavy metadata access, query the `idc-index` Parquet files
+(`references/parquet_access_guide.md`) or BigQuery instead of driving this API hard.
 
 Size-capped responses carry a `truncated` boolean: `false` means the result is complete, `true`
 means raise the limit or aggregate/narrow instead. Explore narrow, then widen.
 
-Errors are HTTP 400 with a uniform body:
+Errors come in two shapes. Semantic problems are HTTP 400 with a uniform body:
 
 ```json
 {"error": {"code": "invalid_query", "message": "Unknown or non-term filter attribute: 'NotAnAttribute'. Use list_attributes to see valid attributes."}}
 ```
 
-The messages are actionable — an unknown attribute names the discovery call to make, and a bad
-column name carries DuckDB's candidate bindings. Read the message and fix the request rather
-than retrying it unchanged.
+Request-shape problems are HTTP 422 with FastAPI's `detail[]` array, which names the offending
+key — a bare filter object, an unrecognized key, or a misspelled range bound all land here. Both
+kinds are actionable: an unknown attribute names the discovery call to make, and a bad column name
+carries DuckDB's candidate bindings. Read the message and fix the request rather than retrying it
+unchanged.
 
-Note what does **not** produce an error: an ignored filter key, an unfilterable-but-valid JSON
-body, and a value with the wrong casing all return HTTP 200. Validation catches malformed types
-(a string where a list is expected → 422), not semantically empty or over-broad requests.
+What does **not** produce an error is a filter that is valid but empty or over-broad. Those return
+HTTP 200 with a `warnings` entry saying so — see *The server reports what it filtered on*. Read
+`warnings`; do not infer from the count alone.
 
 ## Handing Off to idc-index
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -7,7 +7,7 @@ IDC-specific tool names. Those names are a contract with a service that versions
 independently of this repository, so they can go stale silently. These tests read the
 expectations out of the documentation and check them against the live server.
 
-The server is at beta (3.0.0b2) and its tool set may still move. A drift failure here means
+The server is at beta (3.0.0b3) and its tool set may still move. A drift failure here means
 the docs need updating, not that the skill is broken — the skill falls back to idc-index
 whenever identification fails.
 

--- a/tests/test_rest_api.py
+++ b/tests/test_rest_api.py
@@ -3,12 +3,13 @@ Contract tests for the hosted IDC REST API documented in references/rest_api_gui
 
 The guide documents an API that versions independently of this repository — endpoint paths,
 filterable attributes, request body shapes, and row caps are all a contract with a beta
-service (3.0.0b2) that can move without notice. These tests parse the expectations out of the
+service (3.0.0b3) that can move without notice. These tests parse the expectations out of the
 guide and check them against the live API, so drift shows up as a CI failure rather than as
 wrong instructions to an agent.
 
-A failure here means the guide needs updating, not that the skill is broken — the skill's
-default path is idc-index, which does not touch the API.
+A failure here means the guide needs updating, not that the skill is broken. The skill routes
+read-only metadata to this API when idc-index is not installed, so drift here does reach users —
+but downloads and local analysis stay on idc-index, which never touches the API.
 
 Network tests skip (not fail) when the API is unreachable, so an outage does not turn CI red.
 Tests that only read documentation files run offline.
@@ -26,12 +27,24 @@ _ROOT = os.path.join(os.path.dirname(__file__), "..")
 _SKILL_MD = os.path.join(_ROOT, "SKILL.md")
 _REST_GUIDE = os.path.join(_ROOT, "references", "rest_api_guide.md")
 
-BASE_URL = "https://api.imaging.datacommons.cancer.gov/v3"
+# The URL the skill hands to users; documentation assertions always check this one.
+DOCUMENTED_BASE_URL = "https://api.imaging.datacommons.cancer.gov/v3"
+# What the live tests probe. Override with IDC_API_BASE to verify the contract against a staging
+# deployment before it reaches production.
+BASE_URL = os.environ.get("IDC_API_BASE", DOCUMENTED_BASE_URL)
 TIMEOUT = 30
 
-# Body shapes documented in "An empty filter is not an error — check the body shape".
-FILTER_DIRECT = ("/cohort/counts", "/licenses")
-FILTER_WRAPPED = ("/cohort/manifest", "/cohort/manifest.txt", "/citations")
+# Every filtered endpoint takes the filter object under a single `filters` key. The endpoints
+# that enumerate series additionally require at least one predicate; the aggregate ones answer an
+# unfiltered filter with a warning instead.
+FILTERED_ENDPOINTS = ("/cohort/counts", "/licenses", "/cohort/manifest",
+                      "/cohort/manifest.txt", "/citations")
+REQUIRE_A_PREDICATE = ("/cohort/manifest", "/cohort/manifest.txt")
+
+
+def _filtered(path, filters, **extra):
+    """POST `path` with the documented body shape: the filter under `filters`."""
+    return _request(path, {"filters": filters, **extra})
 
 
 def _read(path):
@@ -120,7 +133,7 @@ class TestDocumentedContract:
     def test_skill_md_points_at_the_guide(self):
         skill = _read(_SKILL_MD)
         assert "references/rest_api_guide.md" in skill
-        assert BASE_URL in skill, "SKILL.md does not name the REST API base URL"
+        assert DOCUMENTED_BASE_URL in skill, "SKILL.md does not name the REST API base URL"
 
     def test_guide_documents_every_surface(self):
         paths = {path for _, path in documented_endpoints()}
@@ -148,13 +161,26 @@ class TestDocumentedContract:
             "SKILL.md must name the direct-bucket fallback; the failure it avoids is silent"
         )
 
-    def test_body_shape_split_is_documented(self):
-        # The single most costly mistake against this API: a mis-shaped filter body is not an
-        # error, it silently selects all of IDC.
+    def test_single_body_shape_is_documented(self):
+        # One shape for every filtered endpoint. Before this contract, a mis-shaped body was not
+        # an error — it silently selected all of IDC — so the uniformity is load-bearing.
         body = _read(_REST_GUIDE)
-        assert "An empty filter is not an error" in body
-        for path in FILTER_DIRECT + FILTER_WRAPPED:
+        assert "The server reports what it filtered on" in body
+        assert "always goes under a `filters` key" in body
+        for path in FILTERED_ENDPOINTS:
             assert path.lstrip("/").replace("cohort/", "") in body
+
+    def test_warnings_contract_is_inline_in_skill_md(self):
+        # An agent that never reads `warnings` can still report a count that had a predicate
+        # dropped, so this has to be in the always-loaded file, not only in the guide.
+        skill = _read(_SKILL_MD)
+        assert "always goes under `filters`" in skill, (
+            "SKILL.md must state the single filter body shape"
+        )
+        assert "filters_applied" in skill and "warnings" in skill, (
+            "SKILL.md must tell the agent to read filters_applied/warnings before "
+            "reporting a count"
+        )
 
 
 # ===========================================================================
@@ -232,26 +258,57 @@ class TestFilterableAttributes:
 
 
 class TestCohortSurface:
-    """Filter semantics and the body-shape split the guide warns about."""
+    """Filter semantics, and the reporting that makes a dropped predicate visible."""
 
-    def test_counts_take_the_filter_object_directly(self):
-        counts = _request("/cohort/counts", {"terms": {"collection_id": ["rider_pilot"]}})
+    def test_every_filtered_endpoint_takes_the_same_shape(self):
+        counts = _filtered("/cohort/counts", {"terms": {"collection_id": ["rider_pilot"]}})
         assert 0 < counts["series"] < 10000, counts
+        assert counts["filters_applied"]["terms"] == {"collection_id": ["rider_pilot"]}
+        assert counts["warnings"] == [], counts["warnings"]
 
-    def test_wrapping_the_filter_for_counts_silently_selects_all_of_idc(self):
-        # Documents the failure mode, so the warning in the guide cannot go stale unnoticed.
-        wrapped = _request("/cohort/counts", {"filters": {"terms": {"collection_id": ["rider_pilot"]}}})
-        everything = _request("/cohort/counts", {})
-        assert wrapped == everything, (
-            "the API now rejects or honors a wrapped filter on /cohort/counts; the "
-            "'An empty filter is not an error' warning in rest_api_guide.md needs revisiting"
-        )
+    def test_a_bare_filter_is_rejected_rather_than_ignored(self):
+        # This is the contract the guide rests on. Before it, the bare shape returned all of IDC
+        # at HTTP 200 on these two endpoints, which an agent cannot distinguish from a real count.
+        for path in ("/cohort/counts", "/licenses"):
+            with pytest.raises(urllib.error.HTTPError) as exc:
+                _request(path, {"terms": {"collection_id": ["rider_pilot"]}})
+            assert exc.value.code == 422, f"{path} accepted a bare filter object"
+            assert "filters" in exc.value.read().decode(), (
+                f"the {path} 422 does not name the correct shape"
+            )
 
-    def test_manifest_wraps_the_filter_and_pages(self):
-        manifest = _request(
+    def test_unrecognized_keys_are_refused(self):
+        # A misspelled range bound used to be dropped in silence.
+        with pytest.raises(urllib.error.HTTPError) as exc:
+            _filtered("/cohort/counts", {"ranges": {"instanceCount": {"min": 5}}})
+        assert exc.value.code == 422
+
+    def test_series_enumerating_endpoints_require_a_predicate(self):
+        for path in REQUIRE_A_PREDICATE:
+            with pytest.raises(urllib.error.HTTPError) as exc:
+                _filtered(path, {})
+            assert exc.value.code == 400, f"{path} enumerated an unfiltered cohort"
+
+    def test_aggregate_endpoints_warn_instead_of_answering_silently(self):
+        # "How big is IDC" is legitimate, so counts answers — but says what it did.
+        counts = _filtered("/cohort/counts", {})
+        assert counts["series"] > 1_000_000, counts
+        assert any("ENTIRE IDC" in w for w in counts["warnings"]), counts["warnings"]
+
+    def test_a_predicate_that_constrains_nothing_is_reported(self):
+        # The case no shape check catches: one good predicate plus one empty list still returns a
+        # plausible number, so `warnings` is the only signal that half the filter vanished.
+        counts = _filtered("/cohort/counts",
+                           {"terms": {"collection_id": ["rider_pilot"], "Modality": []}})
+        assert counts["series"] > 0
+        assert "Modality" not in counts["filters_applied"]["terms"]
+        assert any("Modality" in w for w in counts["warnings"]), counts["warnings"]
+
+    def test_manifest_pages(self):
+        manifest = _filtered(
             "/cohort/manifest",
-            {"filters": {"terms": {"collection_id": ["rider_pilot"], "Modality": ["CT"]}},
-             "page": 0, "page_size": 3},
+            {"terms": {"collection_id": ["rider_pilot"], "Modality": ["CT"]}},
+            page=0, page_size=3,
         )
         assert manifest["returned"] == 3
         assert manifest["total_series"] < _request("/stats")["series"], "filter was dropped"
@@ -262,9 +319,9 @@ class TestCohortSurface:
 
     def test_ranges_filter_narrows_the_cohort(self):
         terms = {"collection_id": ["rider_pilot"], "Modality": ["CT"]}
-        unranged = _request("/cohort/counts", {"terms": terms})
-        ranged = _request("/cohort/counts",
-                          {"terms": terms, "ranges": {"instanceCount": {"gte": 100}}})
+        unranged = _filtered("/cohort/counts", {"terms": terms})
+        ranged = _filtered("/cohort/counts",
+                           {"terms": terms, "ranges": {"instanceCount": {"gte": 100}}})
         assert 0 < ranged["series"] < unranged["series"]
 
     def test_manifest_txt_returns_s3_urls(self):
@@ -284,12 +341,23 @@ class TestCohortSurface:
 
     def test_unknown_attribute_is_rejected(self):
         with pytest.raises(urllib.error.HTTPError) as exc:
-            _request("/cohort/counts", {"terms": {"NotAnAttribute": ["x"]}})
+            _filtered("/cohort/counts", {"terms": {"NotAnAttribute": ["x"]}})
         assert exc.value.code == 400
         assert json.loads(exc.value.read())["error"]["code"] == "invalid_query"
 
-    def test_miscased_value_returns_zero_rather_than_an_error(self):
-        assert _request("/cohort/counts", {"terms": {"Modality": ["mr"]}})["series"] == 0
+    def test_miscased_value_returns_zero_and_says_why(self):
+        # Zero with a casing warning vs zero with none is what lets an agent tell a typo from a
+        # genuinely empty cohort. The guide tells it to rely on that distinction.
+        miscased = _filtered("/cohort/counts", {"terms": {"Modality": ["mr"]}})
+        assert miscased["series"] == 0
+        assert any("case-sensitive" in w for w in miscased["warnings"]), miscased["warnings"]
+
+        absent = _filtered("/cohort/counts", {"terms": {"collection_id": ["no_such_collection"]}})
+        assert absent["series"] == 0
+        assert absent["warnings"] == [], (
+            "a value that exists in no casing must return zero with no warning, or the "
+            "zero-plus-empty-warnings signal the guide documents is not trustworthy"
+        )
 
 
 class TestSqlSurface:
@@ -345,7 +413,7 @@ class TestAttributionSurface:
     """Licenses and citations, which the skill tells users to check before publishing."""
 
     def test_licenses_are_reported_per_cohort(self):
-        licenses = _request("/licenses", {"terms": {"collection_id": ["rider_pilot"]}})["licenses"]
+        licenses = _filtered("/licenses", {"terms": {"collection_id": ["rider_pilot"]}})["licenses"]
         assert licenses and all({"license_short_name", "series", "size_TB"} <= set(item) for item in licenses)
 
     def test_citations_include_the_idc_acknowledgment(self):

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -95,6 +95,18 @@ class TestAlwaysLoadedGuidance:
             "commercial use gets a wrong answer if this only lives in a reference file"
         )
 
+    def test_access_path_routing_gate_is_inline(self):
+        # Without this, the agent falls back to its prior that idc-index is the one entry point
+        # and pays a ~77 MB install to answer a metadata question. The gate only works if it is
+        # read before the first query, so it cannot move to a reference file.
+        skill = _read(_SKILL_MD)
+        assert "Choose the access path first" in skill, (
+            "SKILL.md must open with the access-path routing gate"
+        )
+        assert "do not install anything" in skill, (
+            "SKILL.md must tell the agent not to install idc-index for read-only metadata"
+        )
+
     def test_prior_versions_index_warning_is_inline(self):
         skill = _read(_SKILL_MD)
         assert "prior_versions_index" in skill


### PR DESCRIPTION
## The problem

`SKILL.md` declared `idc-index` the "primary tool ... the default path, always available", and every inline example assumed `client = IDCClient()`. That left the skill internally inconsistent:

- It already treated the hosted IDC service as **authoritative** for discovery and metadata (`SKILL.md:70-74`) — but only when that service happened to arrive as an MCP server.
- The REST API is the same service over plain HTTP (`rest_api_guide.md:9-11`: "the same service behind two transports"). So the *transport* was deciding the trust level.
- With MCP absent, the agent paid an install to answer a read-only question. Measured: `idc_index_data` alone is **77.4 MB**, before pandas, pyarrow, duckdb, and the bundled s5cmd binary.

## What changed

A four-branch gate replaces the single default, in the Overview where it is read before the first query:

1. Session has the IDC MCP server → route discovery there.
2. Else `idc-index` already installed → use it for everything.
3. Else the task is read-only metadata (counts, attribute values, SQL under 10 000 rows, licenses, citations, viewer URLs) → **REST over `curl`, install nothing**.
4. Else — downloads, pandas/plotting, pydicom/SimpleITK, pathology tiling, >10 000 rows, version-pinned scripts → install `idc-index`.

`idc-index` stays the most capable path and the only one that moves image bytes. The rule is just not to pay for it before the task calls for it.

**This is a task split, not a swap.** REST cannot replace `idc-index`: it never moves image bytes (every download path bottoms out at `idc` or `s5cmd`), and `POST /sql` is hard-capped at 10 000 rows against ~1 M series.

## The API fix did most of the work

Routing metadata to REST used to mean documenting an agent-hostile failure mode: a mis-shaped filter body returned **all of IDC at HTTP 200**, which an agent cannot distinguish from a real count. [IDC-REST-MCP#44](https://github.com/ImagingDataCommons/IDC-REST-MCP/pull/44) closed that, and it is live in `3.0.0b3`.

So the inline caveat went from ~14 lines to ~4 — which is what kept `SKILL.md` at **495/500** lines without raising the budget:

| Would have gone inline | Now |
|---|---|
| Direct-vs-wrapped body shape, per endpoint | One shape: filter always under `filters` |
| "Wrong shape returns all of IDC at HTTP 200" | Deleted — it is a 422 naming the fix |
| "Miscased value returns ambiguous zeros" | Deleted — self-explaining via `warnings` |
| Undocumented rate limit | Documented: no per-caller limit, no `429` |

The documented contract is now: one body shape, misuse refused with `422`/`400`, and every filtered response echoing `filters_applied` and `warnings` — so **a zero count with empty `warnings` positively means "filter applied, matched nothing."**

## Corrections

- `cohort/manifest.txt` enumerates up to **100 000 series**; the guide called it uncapped.
- The API publishes **no per-caller rate limit or quota** and no `429` — previously an open question, and an argument against routing traffic here.
- Stop hardcoding bare `pip install` commands. They target whichever interpreter `pip` resolves to and ignore the pinned version, which is the exact failure `scripts/check_version.py` exists to prevent; the docs now defer to it.

## CI

- `test_structure.py` pins the routing gate; `test_rest_api.py` pins the single body shape and the `warnings` contract. A future trim cannot revert either silently.
- `test_rest_api.py` now encodes the new contract, making it a prod-regression detector. Confirmed it fails loudly on the old contract — 9 failures, all confined to `TestCohortSurface`, including `assert 1032911 == 0`.
- `IDC_API_BASE` overrides the probed deployment so the contract can be checked against staging first; documentation assertions always check the published URL.

## Verification

Against production `3.0.0b3` (build `0640860`):

- **52 passed** across `test_structure`, `test_rest_api`, `test_mcp_server` — no skips, so the header-drift check actively confirmed `3.0.0b3` rather than passing vacuously.
- All five documented REST snippets run verbatim.
- Adversarially probed for residual silent-drop paths and found none, including the case no shape check catches: one good predicate plus one that constrains nothing returns a plausible number, and only `warnings` reveals the dropped half.
- `test_snippets.py`: 97 passed, 1 failed — **pre-existing and unrelated**, local venv has idc-index 0.12.3 against the pinned 0.12.5. CI installs the pinned version.

## Notes for review

Two observations from vetting the API, neither blocking and both outside #44's scope:

- `source` is now a `422` on `cohort/manifest` (JSON) while staying valid on `manifest.txt`. Correct — it only ever affected the `.txt` surface — but it is a newly loud rejection of a previously harmless key.
- `manifest.txt` with `source: gcs` still returns `s3://` URLs. Pre-existing and documented, but now that every other misuse is loud, it is the one parameter left that appears to do something other than what it does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
