### PR TITLE
Stop hardcoding pip commands in USAGE.md

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -26,8 +26,8 @@ This gives Claude the complete skill with all the reference guides in one upload
 
 1. Go to **Settings > Capabilities** in Claude.ai
 2. Under **Code execution and file creation**:
-   - Enable "Allow network egress" so that Claude can install `idc-index` package and its components
-   - Under "Domain whitelist" select "Package managers only" so that `idc-index` package can be pulled from PyPI
+   - Enable "Allow network egress" so that Claude can reach IDC and, when a task needs it, install the `idc-index` package
+   - Under "Domain whitelist" select "Package managers only" so that `idc-index` can be pulled from PyPI
 3. Under **Additional allowed domains** add the following:
      * `*.github.com` and `*.githubusercontent.com`: used to access source code and release artifacts
      * `*.googleapis.com`: used to fetch IDC data from Google Storage buckets
@@ -257,8 +257,8 @@ Assistant: [Checks license and explains usage restrictions]
 
 ### Command Execution
 
-- **Assistants with code execution** (e.g., Claude Desktop, Claude Code, other coding agents): Can execute commands directly, such as installing `idc-index` with pip
-- **Assistants without code execution**: Can only provide guidance. Users will need to manually run installation commands like `pip install idc-index`
+- **Assistants with code execution** (e.g., Claude Desktop, Claude Code, other coding agents): Can execute commands directly
+- **Assistants without code execution**: Can only provide commands for the user to run
 
 ### Data Access
 
@@ -284,7 +284,7 @@ Assistant: [Checks license and explains usage restrictions]
 
 - **Python environment**: Ensure Python 3.10+ is installed and accessible (idc-index requires Python >= 3.10)
 - **Network access**: Verify internet connectivity for pip installations
-- **Permissions**: Some systems may require `pip install --user idc-index` instead
+- **Use the command the skill prints**: `scripts/check_version.py` emits an install command that targets the interpreter actually running and pins the vetted version; a bare `pip` may resolve to a different environment. On an externally managed Python (PEP 668) you will need a virtual environment or `--user`
 
 ### BigQuery or DICOMweb Issues
 


### PR DESCRIPTION
Follow-up to #36, which removed hardcoded `pip install` commands from `SKILL.md` but left three in `USAGE.md`.

## Why

`scripts/check_version.py` exists to emit an install command that targets the interpreter actually running and pins the vetted version. A bare `pip install idc-index` defeats both: it may resolve to a different environment than the one importing the package, and it ignores the pin. `USAGE.md` still handed out `pip install idc-index` and `pip install --user idc-index` directly, and justified network egress solely as "so that Claude can install `idc-index`".

## Changes

- Troubleshooting points at `check_version.py` and explains why, keeping the PEP 668 note that the old `--user` bullet carried
- The Command Execution list no longer names an install command — the distinction it draws is whether the assistant can execute, not what it installs
- The egress step reads "reach IDC and, when a task needs it, install `idc-index`", since the API path needs no package

## Scope

Deliberately *not* documenting which access path the skill picks per task. That is the assistant's decision from `SKILL.md`, and a human configuring the skill cannot act on it — so it would be noise in a setup doc. The one exception is the allowed-domains list, where it genuinely changes what they configure; that was already covered in #36.

`README.md` is unchanged for the same reason.

Verified: 52 passed across `test_structure`, `test_rest_api`, `test_mcp_server`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
