### PR TITLE
Release 1.8.1: make the bundle a straight copy for downstream registries

### DIFF
--- a/.github/workflows/test-snippets.yml
+++ b/.github/workflows/test-snippets.yml
@@ -8,6 +8,7 @@ on:
       - 'SKILL.md'
       - 'USAGE.md'
       - 'references/**'
+      - 'scripts/**'
       - 'tests/**'
       - '.github/workflows/test-snippets.yml'
   pull_request:
@@ -15,6 +16,7 @@ on:
       - 'SKILL.md'
       - 'USAGE.md'
       - 'references/**'
+      - 'scripts/**'
       - 'tests/**'
       - '.github/workflows/test-snippets.yml'
   workflow_dispatch:
@@ -40,10 +42,11 @@ jobs:
       - name: Install test dependencies
         run: pip install -r tests/requirements-test.txt
 
-      # Pure file checks (line budget, link resolution, always-loaded content).
-      # Runs first: it is fast and catches structural regressions before the slow suites.
-      - name: Run structure contract tests
-        run: pytest tests/test_structure.py -v
+      # Pure file checks (line budget, link resolution, always-loaded content) plus the
+      # offline contract for scripts/check_version.py. Runs first: no network and no
+      # idc-index needed, so it catches structural regressions before the slow suites.
+      - name: Run structure and script contract tests
+        run: pytest tests/test_structure.py tests/test_check_version.py -v
 
       - name: Run snippet tests
         run: pytest tests/test_snippets.py -v --timeout=300

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,39 @@ All notable changes to the Imaging Data Commons Skill are documented in this fil
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.8.1] - 2026-08-10
+
+Conformance pass from review of the downstream sync in
+[K-Dense-AI/scientific-agent-skills#158](https://github.com/K-Dense-AI/scientific-agent-skills/pull/158):
+each item was a local edit a registry had to make to the vendored copy, so fixing it here
+keeps the next sync a straight file copy.
+
+### Fixed
+
+- `SKILL.md` frontmatter indents `metadata` two spaces, not four. Four is valid YAML, but
+  registry validators that read frontmatter line by line see only two-space nesting and
+  report `metadata.version` as missing. Pinned by `tests/test_structure.py`
+
+### Changed
+
+- No hardcoded installer commands in the bundle: `SKILL.md` and the guides name the package
+  needed and point at `scripts/check_version.py` instead of printing `pip install …`, which
+  targets whichever interpreter `pip` resolves to, drops the pinned version, and collides
+  with environments standardized on another installer. Guarded by `tests/test_structure.py`
+- `check_version.py` prefers `uv` when on `PATH`, with `--python` so it targets the
+  interpreter that failed to import `idc_index` rather than the active environment. Neither
+  form overrides PEP 668
+
+### Added
+
+- `tests/test_check_version.py`: offline, standard-library-only contract for the bundled
+  script — version parsing, install-command construction, exit codes, best-effort network
+  notices, and guards that it never shells out to an installer or bypasses PEP 668. Runs
+  with nothing installed, so a registry that requires a suite for any skill shipping
+  `scripts/` can use it as-is; the duplicated cases left `tests/test_snippets.py`
+- `scripts/**` to the `test-snippets.yml` path filters — a change to the bundled script did
+  not trigger CI
+
 ## [1.8.0] - 2026-08-10
 
 ### Added

--- a/SKILL.md
+++ b/SKILL.md
@@ -3,11 +3,11 @@ name: imaging-data-commons
 description: Query and download public cancer imaging data from NCI Imaging Data Commons. Invoke for any question about IDC collections, cancer imaging datasets, DICOM data access, radiology (CT, MR, PET) or pathology AI training sets, metadata queries, visualization, or license checks — even when the user doesn't explicitly mention "IDC". No authentication required.
 license: This skill is provided under the MIT License. IDC data itself has individual licensing (mostly CC-BY, some CC-NC) that must be respected when using the data.
 metadata:
-    version: 1.8.0
-    skill-author: Andrey Fedorov, @fedorov
-    idc-index: "0.12.5"
-    idc-data-version: "v24"
-    repository: https://github.com/ImagingDataCommons/imaging-data-commons-skill
+  version: 1.8.1
+  skill-author: Andrey Fedorov, @fedorov
+  idc-index: "0.12.5"
+  idc-data-version: "v24"
+  repository: https://github.com/ImagingDataCommons/imaging-data-commons-skill
 ---
 
 # Imaging Data Commons
@@ -35,8 +35,8 @@ on the session and the task.
 4. **Not installed, and the task needs more than metadata** — downloading files, pandas or
    plotting, pydicom/SimpleITK, pathology tiling, results past 10 000 rows, or a version-pinned
    script the user re-runs? Install `idc-index`: `check_version.py` exits non-zero and prints
-   the exact `pip install` command for the running interpreter. Prefer a virtual environment,
-   then restart Python.
+   the exact install command for the running interpreter. Prefer a virtual environment, then
+   restart Python.
 
 `idc-index` ([GitHub](https://github.com/imagingdatacommons/idc-index)) is still the most
 capable path and the only one that moves image bytes; the rule is just not to pay for it before
@@ -267,7 +267,7 @@ queries, or Google Healthcare (GCP auth) for production volumes. See
 **Direct Parquet access**
 
 The idc-index metadata tables are also published as Parquet on a public GCS bucket
-(`idc-index-data-artifacts`), queryable with DuckDB or pandas. This needs `pip install duckdb`
+(`idc-index-data-artifacts`), queryable with DuckDB or pandas. This needs DuckDB installed
 and cannot reach the per-collection clinical tables, so prefer REST `/sql` for ad-hoc metadata;
 choose Parquet to pin a data version or for results past the REST row cap. See
 `references/parquet_access_guide.md`.

--- a/references/bigquery_guide.md
+++ b/references/bigquery_guide.md
@@ -660,7 +660,7 @@ from google.cloud import bigquery
 from idc_index import IDCClient
 
 # Initialize BigQuery client
-# Requires: pip install google-cloud-bigquery
+# Requires: the Python google-cloud-bigquery package
 # Auth: gcloud auth application-default login
 # Project: needed for billing even on public datasets (free tier applies)
 bq_client = bigquery.Client(project="your-gcp-project-id")

--- a/references/cli_guide.md
+++ b/references/cli_guide.md
@@ -4,9 +4,8 @@ The `idc-index` package provides command-line tools for downloading DICOM data f
 
 ## Installation
 
-```bash
-pip install --upgrade idc-index
-```
+Needs `idc-index` installed — run `python scripts/check_version.py`, which reports the installed
+version and prints the install command for the interpreter you are running.
 
 After installation, the `idc` command is available in your terminal.
 

--- a/references/clinical_data_guide.md
+++ b/references/clinical_data_guide.md
@@ -16,9 +16,8 @@ For basic clinical data access, see the "Clinical Data Access" section in the ma
 
 ## Prerequisites
 
-```bash
-pip install --upgrade idc-index
-```
+Needs `idc-index` installed — run `python scripts/check_version.py`, which reports the installed
+version and prints the install command for the interpreter you are running.
 
 No BigQuery credentials required - clinical data is packaged with `idc-index`.
 

--- a/references/index_tables_guide.md
+++ b/references/index_tables_guide.md
@@ -17,9 +17,8 @@ For SQL query examples (filter discovery, finding annotations, size estimation),
 
 ## Prerequisites
 
-```bash
-pip install --upgrade idc-index
-```
+Needs `idc-index` installed — run `python scripts/check_version.py`, which reports the installed
+version and prints the install command for the interpreter you are running.
 
 ## Available Tables
 

--- a/references/parquet_access_guide.md
+++ b/references/parquet_access_guide.md
@@ -6,7 +6,7 @@ All idc-index metadata tables are published as Parquet files to a public GCS buc
 
 **Limitation:** download helpers (`download_from_selection()`), viewer URLs (`get_viewer_URL()`), and citation generation require the idc-index client and are not available from raw Parquet files.
 
-**This is not the first no-install option to reach for.** It still needs `pip install duckdb`, and the per-collection clinical tables are not published here — only the `clinical_index` dictionary. For ad-hoc metadata with nothing installed, the REST API (`rest_api_guide.md`) needs no install at all and reaches `clinical.<table>` through `POST /sql`.
+**This is not the first no-install option to reach for.** It still needs DuckDB installed, and the per-collection clinical tables are not published here — only the `clinical_index` dictionary. For ad-hoc metadata with nothing installed, the REST API (`rest_api_guide.md`) needs no install at all and reaches `clinical.<table>` through `POST /sql`.
 
 ## When to Use This Guide
 
@@ -50,10 +50,8 @@ https://storage.googleapis.com/idc-index-data-artifacts/current/release_artifact
 
 ## Prerequisites
 
-```bash
-pip install duckdb
-# or: uv add duckdb
-```
+Install the Python `duckdb` package, using whatever installer manages the environment you are
+running in.
 
 DuckDB reads Parquet directly from HTTPS URLs using HTTP range requests — no GCS client library or authentication required.
 

--- a/references/rest_api_guide.md
+++ b/references/rest_api_guide.md
@@ -105,9 +105,9 @@ Comparing `idc_version` alone cannot make this distinction in the other directio
 but says nothing about the index build.
 
 When the two disagree, say so and name both versions, then reconcile rather than mixing
-results: `pip install --upgrade idc-index` brings the local side to the newer
-`idc-index-data`, and `python scripts/check_version.py` reports whether an upgrade is
-available. Do not present API-derived and locally-derived counts side by side as if they came
+results: upgrading `idc-index` brings the local side to the newer `idc-index-data`, and
+`python scripts/check_version.py` reports whether an upgrade is available and prints the
+command for the interpreter you are running. Do not present API-derived and locally-derived counts side by side as if they came
 from one index.
 
 **A major behind also breaks downloads.** `idc-index` resolves every `s3://` URL it is given
@@ -444,7 +444,7 @@ curl -s $B/cohort/manifest.txt \
   -H 'content-type: application/json' \
   -d '{"filters": {"terms": {"collection_id": ["rider_pilot"]}}}' > idc_manifest.txt
 
-# download it (pip install idc-index)
+# download it (needs idc-index installed)
 idc download-from-manifest idc_manifest.txt --download-dir ./idc-data
 ```
 
@@ -480,7 +480,8 @@ not contain are silently dropped from the selection.
 
 **Fix it one of two ways:**
 
-1. **Upgrade** — `pip install --upgrade idc-index`, then re-run. This is the right answer
+1. **Upgrade** — upgrade `idc-index` (`python scripts/check_version.py` prints the command),
+   then re-run. This is the right answer
    whenever it is possible; it restores the hierarchy, size checks, and progress reporting.
 2. **Bypass the index** — transfer directly from the bucket. The manifest URLs are
    self-contained (`s3://<bucket>/<crdc_series_uuid>/*`), so no index is needed at all:

--- a/references/sql_patterns.md
+++ b/references/sql_patterns.md
@@ -20,9 +20,8 @@ For table schemas, DataFrame access, and join column references, see `references
 
 ## Prerequisites
 
-```bash
-pip install --upgrade idc-index
-```
+Needs `idc-index` installed — run `python scripts/check_version.py`, which reports the installed
+version and prints the install command for the interpreter you are running.
 
 ```python
 from idc_index import IDCClient

--- a/references/use_cases.md
+++ b/references/use_cases.md
@@ -16,9 +16,8 @@ For core API patterns (query, download, visualize, citations), see the "Core Cap
 
 ## Prerequisites
 
-```bash
-pip install --upgrade idc-index
-```
+Needs `idc-index` installed — run `python scripts/check_version.py`, which reports the installed
+version and prints the install command for the interpreter you are running.
 
 ## Use Case 1: Find and Download Lung CT Scans for Deep Learning
 

--- a/scripts/check_version.py
+++ b/scripts/check_version.py
@@ -5,7 +5,8 @@ Run FIRST at the start of an IDC session:  python scripts/check_version.py
 
 - Verifies that idc-index is installed and at least MIN_VERSION. It never
   installs or upgrades anything itself: if the requirement is not met it prints
-  the exact command to run and exits non-zero, leaving the choice of Python
+  the command to run — targeting the interpreter that ran this script, via uv
+  when uv is available — and exits non-zero, leaving the choice of Python
   environment to the caller.
 - Notifies (only) when a newer idc-index (PyPI) or skill release (GitHub) is
   available. Network checks are best-effort and silently skipped offline.
@@ -13,10 +14,11 @@ Run FIRST at the start of an IDC session:  python scripts/check_version.py
 Keep MIN_VERSION and SKILL_VERSION in sync with the SKILL.md frontmatter.
 """
 import re
+import shutil
 import sys
 
 MIN_VERSION = "0.12.5"   # keep in sync with metadata.idc-index in SKILL.md
-SKILL_VERSION = "1.8.0"  # keep in sync with metadata.version in SKILL.md
+SKILL_VERSION = "1.8.1"  # keep in sync with metadata.version in SKILL.md
 REPO = "ImagingDataCommons/imaging-data-commons-skill"
 
 _LEADING_DIGITS = re.compile(r"\d+")
@@ -51,11 +53,33 @@ def fetch_json(url, *keys):
         return None
 
 
+def install_commands(spec, upgrade=False):
+    """Install commands for the interpreter running this script, preferred first.
+
+    `-m pip` is always offered: every standard interpreter ships it, and naming the
+    interpreter explicitly keeps the install out of whatever other environment a bare
+    `pip` on PATH would resolve to. `uv` is offered ahead of it when it is on PATH, with
+    `--python` for the same reason — otherwise `uv pip install` targets the active
+    virtual environment, which is not necessarily this one.
+
+    Neither form overrides the PEP 668 guard on an externally managed interpreter. Both
+    refuse there, which is the intended outcome, not a gap to work around.
+    """
+    flag = "--upgrade " if upgrade else ""
+    commands = [f"{sys.executable} -m pip install {flag}'{spec}'"]
+    if shutil.which("uv"):
+        commands.insert(0, f"uv pip install --python {sys.executable} {flag}'{spec}'")
+    return commands
+
+
 def print_install_instructions(spec):
     """Print how to install `spec` — this script never modifies the environment."""
-    print(f"\nInstall the vetted version with:\n\n    {sys.executable} -m pip install '{spec}'\n")
+    print("\nInstall the vetted version with:\n")
+    for command in install_commands(spec):
+        print(f"    {command}")
+    print()
     print("Use a virtual environment where you can; on an externally managed system Python")
-    print("(PEP 668) pip refuses to install until you use a virtual environment or `--user`.")
+    print("(PEP 668) the install is refused until you use a virtual environment or `--user`.")
     print("Re-run this script once the install finishes.")
 
 
@@ -89,7 +113,7 @@ def notify_updates(installed):
         pkg = fetch_json("https://pypi.org/pypi/idc-index/json", "info", "version")
         if pkg and parse_version(pkg) > parse_version(installed):
             print(f"ℹ️ idc-index {pkg} available — to update: "
-                  f"{sys.executable} -m pip install --upgrade idc-index")
+                  f"{install_commands('idc-index', upgrade=True)[0]}")
 
     tag = fetch_json(f"https://api.github.com/repos/{REPO}/releases/latest", "tag_name")
     if tag and parse_version(tag) > parse_version(SKILL_VERSION):

--- a/tests/test_check_version.py
+++ b/tests/test_check_version.py
@@ -1,0 +1,184 @@
+"""
+Contract for scripts/check_version.py — the one script the skill bundles.
+
+Deliberately offline and dependency-free: no network, no idc-index install, standard
+library plus pytest only. That keeps the startup check testable in environments where
+the rest of the suite skips, and lets a downstream skill registry that vendors the
+bundle run this file as-is (several of them require a test suite for any skill that
+ships `scripts/`, and cannot install scientific packages to get one).
+
+Importing the module must stay side-effect free for the same reason: `idc_index`,
+`json`, and `urllib` are all imported inside the functions that need them.
+"""
+
+import os
+import re
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+import check_version  # noqa: E402
+
+_SKILL_MD = os.path.join(os.path.dirname(__file__), "..", "SKILL.md")
+
+
+class TestParseVersion:
+    def test_orders_numerically(self):
+        # String comparison would (wrongly) order "0.12.0" < "0.9.0".
+        assert check_version.parse_version("0.12.0") > check_version.parse_version("0.9.0")
+
+    def test_strips_v_prefix(self):
+        assert check_version.parse_version("v1.6.5") == (1, 6, 5)
+
+    def test_tolerates_prereleases(self):
+        # A pre-release tag upstream must not crash the startup check. It compares equal
+        # to its base release, so the update notices stay conservative.
+        assert check_version.parse_version("0.13.0rc1") == (0, 13, 0)
+        assert check_version.parse_version("v1.7.0-beta") == (1, 7, 0)
+        assert check_version.parse_version("0.13.0rc1") == check_version.parse_version("0.13.0")
+
+    def test_pads_short_versions(self):
+        assert check_version.parse_version("1.7") == (1, 7, 0)
+        assert check_version.parse_version("2") == (2, 0, 0)
+
+    def test_ignores_components_past_the_third(self):
+        assert check_version.parse_version("1.2.3.4") == (1, 2, 3)
+
+
+class TestInstallCommands:
+    """The printed command must name this interpreter, and must not override PEP 668."""
+
+    def test_pip_form_targets_the_running_interpreter(self, monkeypatch):
+        monkeypatch.setattr(check_version.shutil, "which", lambda _: None)
+        commands = check_version.install_commands("idc-index==0.12.5")
+        assert commands == [f"{sys.executable} -m pip install 'idc-index==0.12.5'"]
+
+    def test_uv_form_is_preferred_when_uv_is_available(self, monkeypatch):
+        monkeypatch.setattr(check_version.shutil, "which", lambda name: f"/usr/bin/{name}")
+        commands = check_version.install_commands("idc-index==0.12.5")
+        assert len(commands) == 2
+        # uv pip install without --python targets the *active* environment, which is not
+        # necessarily the one that failed to import idc_index.
+        assert commands[0] == (
+            f"uv pip install --python {sys.executable} 'idc-index==0.12.5'"
+        )
+        assert commands[1].startswith(f"{sys.executable} -m pip install")
+
+    def test_upgrade_flag_applies_to_every_form(self, monkeypatch):
+        monkeypatch.setattr(check_version.shutil, "which", lambda name: f"/usr/bin/{name}")
+        commands = check_version.install_commands("idc-index", upgrade=True)
+        assert all("--upgrade" in command for command in commands)
+
+    def test_no_command_bypasses_an_externally_managed_interpreter(self, monkeypatch):
+        monkeypatch.setattr(check_version.shutil, "which", lambda name: f"/usr/bin/{name}")
+        for spec in ("idc-index", "idc-index==0.12.5"):
+            for command in check_version.install_commands(spec, upgrade=True):
+                assert "--break-system-packages" not in command
+                assert "--system" not in command
+
+    def test_instructions_name_the_version_and_the_interpreter(self, capsys):
+        check_version.print_install_instructions(f"idc-index=={check_version.MIN_VERSION}")
+        out = capsys.readouterr().out
+        assert check_version.MIN_VERSION in out
+        assert sys.executable in out
+        assert "virtual environment" in out
+
+
+class TestNeverInstalls:
+    """The script reports and instructs; it must not mutate the environment.
+
+    Auto-installing into whatever interpreter `pip` happens to resolve to can silently
+    rewrite a user's global site-packages — and, with a capped dependency, downgrade a
+    package the environment needs. Installation is the caller's decision.
+    """
+
+    def _source(self):
+        with open(check_version.__file__, encoding="utf-8") as handle:
+            return handle.read()
+
+    def test_source_has_no_installer_call(self):
+        for forbidden in ("subprocess", "--break-system-packages", "pip3", "os.system"):
+            assert forbidden not in self._source(), (
+                f"check_version.py must not use {forbidden}"
+            )
+
+    def test_source_has_no_dynamic_execution(self):
+        # Downstream registries reject bundled scripts that call eval/exec.
+        for forbidden in ("eval(", "exec("):
+            assert forbidden not in self._source()
+
+
+class TestMinimumCheck:
+    """check_minimum() reports the installed version, or None with instructions."""
+
+    def test_missing_package_reports_none_and_instructs(self, monkeypatch, capsys):
+        # `None` in sys.modules makes `import idc_index` raise ImportError, so this test
+        # exercises the not-installed path whether or not the package is present.
+        monkeypatch.setitem(sys.modules, "idc_index", None)
+        assert check_version.check_minimum() is None
+        out = capsys.readouterr().out
+        assert "not installed" in out
+        assert check_version.MIN_VERSION in out
+
+    def test_older_version_reports_none(self, monkeypatch, capsys):
+        monkeypatch.setitem(sys.modules, "idc_index", _FakeIdcIndex("0.9.0"))
+        assert check_version.check_minimum() is None
+        assert "below the pinned minimum" in capsys.readouterr().out
+
+    def test_current_version_is_returned(self, monkeypatch, capsys):
+        monkeypatch.setitem(sys.modules, "idc_index", _FakeIdcIndex("99.0.0"))
+        assert check_version.check_minimum() == "99.0.0"
+        assert "meets pinned minimum" in capsys.readouterr().out
+
+    def test_main_exit_code_follows_the_check(self, monkeypatch):
+        monkeypatch.setattr(check_version, "notify_updates", lambda _: None)
+        monkeypatch.setattr(check_version, "check_minimum", lambda: None)
+        assert check_version.main() == 1
+        monkeypatch.setattr(check_version, "check_minimum", lambda: "0.12.5")
+        assert check_version.main() == 0
+
+
+class TestNetworkChecksAreBestEffort:
+    def test_fetch_json_returns_none_when_unreachable(self):
+        # .invalid never resolves (RFC 2606), so this stays offline.
+        assert check_version.fetch_json("https://pypi.invalid/pypi/idc-index/json", "info") is None
+
+    def test_notify_updates_survives_an_unreachable_network(self, monkeypatch):
+        monkeypatch.setattr(check_version, "fetch_json", lambda *args, **kwargs: None)
+        check_version.notify_updates("0.12.5")  # must not raise
+
+    def test_skill_update_notice_is_conservative(self, monkeypatch, capsys):
+        # A GitHub tag equal to the shipped version is not an update.
+        monkeypatch.setattr(
+            check_version, "fetch_json", lambda *args, **kwargs: f"v{check_version.SKILL_VERSION}"
+        )
+        check_version.notify_updates(None)
+        assert "available" not in capsys.readouterr().out
+
+
+class TestVersionsMatchFrontmatter:
+    """The pins in the script and in SKILL.md are read by different consumers."""
+
+    def _frontmatter(self):
+        with open(_SKILL_MD, encoding="utf-8") as handle:
+            return handle.read().split("---", 2)[1]
+
+    def test_min_version_matches_metadata(self):
+        meta = re.search(r'idc-index:\s*"?([\d.]+)"?', self._frontmatter()).group(1)
+        assert check_version.MIN_VERSION == meta
+
+    def test_skill_version_matches_metadata(self):
+        meta = re.search(r"version:\s*\"?([\d.]+)\"?", self._frontmatter()).group(1)
+        assert check_version.SKILL_VERSION == meta
+
+
+class _FakeIdcIndex:
+    """Stand-in for the real package, so the check runs with nothing installed."""
+
+    def __init__(self, version):
+        self.__version__ = version
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/tests/test_snippets.py
+++ b/tests/test_snippets.py
@@ -16,7 +16,6 @@ BigQuery snippets are covered separately in test_bq_snippets.py (uses bq CLI dry
 """
 
 import os
-import re
 import sys
 
 import duckdb
@@ -27,8 +26,6 @@ from idc_index import IDCClient
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
 import check_version  # noqa: E402
-
-_SKILL_MD = os.path.join(os.path.dirname(__file__), "..", "SKILL.md")
 
 
 # ---------------------------------------------------------------------------
@@ -73,50 +70,12 @@ class TestVersionAndSetup:
     """
 
     def test_package_version_meets_minimum(self):
+        # The rest of check_version.py — parsing, install instructions, exit codes — is
+        # covered offline in test_check_version.py; this needs the package installed.
         assert (
             check_version.parse_version(idc_index.__version__)
             >= check_version.parse_version(check_version.MIN_VERSION)
         ), f"idc-index {idc_index.__version__} < pinned minimum {check_version.MIN_VERSION}"
-
-    def test_parse_version_orders_numerically(self):
-        # String comparison would (wrongly) order "0.12.0" < "0.9.0".
-        assert check_version.parse_version("0.12.0") > check_version.parse_version("0.9.0")
-        assert check_version.parse_version("v1.6.5") == (1, 6, 5)
-
-    def test_parse_version_tolerates_prereleases(self):
-        # A pre-release tag upstream must not crash the startup check.
-        assert check_version.parse_version("0.13.0rc1") == (0, 13, 0)
-        assert check_version.parse_version("v1.7.0-beta") == (1, 7, 0)
-        assert check_version.parse_version("1.7") == (1, 7, 0)
-
-    def test_fetch_json_returns_none_when_unreachable(self):
-        assert check_version.fetch_json("https://pypi.org/pypi/_no_such_pkg_/json", "info") is None
-
-    def test_check_version_never_installs(self):
-        """The script reports and instructs; it must not mutate the environment.
-
-        Auto-installing into whatever interpreter `pip` happens to resolve to can
-        silently rewrite a user's global site-packages, so installation is left to
-        the caller.
-        """
-        with open(check_version.__file__, encoding="utf-8") as fh:
-            source = fh.read()
-        for forbidden in ("subprocess", "--break-system-packages", "pip3"):
-            assert forbidden not in source, f"check_version.py must not use {forbidden}"
-
-    def test_install_instructions_target_running_interpreter(self, capsys):
-        check_version.print_install_instructions(f"idc-index=={check_version.MIN_VERSION}")
-        out = capsys.readouterr().out
-        assert f"{sys.executable} -m pip install" in out
-        assert check_version.MIN_VERSION in out
-
-    def test_script_versions_match_skill_frontmatter(self):
-        with open(_SKILL_MD, encoding="utf-8") as fh:
-            front = fh.read().split("---", 2)[1]
-        idc_index_meta = re.search(r'idc-index:\s*"?([\d.]+)"?', front).group(1)
-        version_meta = re.search(r"version:\s*([\d.]+)", front).group(1)
-        assert check_version.MIN_VERSION == idc_index_meta
-        assert check_version.SKILL_VERSION == version_meta
 
     def test_idc_data_version_is_v24(self, client):
         assert client.get_idc_version() == "v24"

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -124,3 +124,54 @@ class TestFrontmatter:
         assert re.fullmatch(r"\d+\.\d+\.\d+", match.group(1)), (
             f"version {match.group(1)!r} is not MAJOR.MINOR.PATCH"
         )
+
+    def test_metadata_scalars_are_indented_two_spaces(self):
+        """Two spaces, not four — some registry validators only read that form.
+
+        A four-space `metadata` block is valid YAML, and `metadata.version` still parses
+        for anything using a YAML library. Registries that validate frontmatter with a
+        line-oriented parser instead read two-space nesting only, and report the version
+        as missing, so the bundle fails their conformance gate for a whitespace reason.
+        """
+        front = _read(_SKILL_MD).split("---", 2)[1]
+        lines = front.splitlines()
+        start = next(i for i, line in enumerate(lines) if line.startswith("metadata:"))
+        nested = []
+        for line in lines[start + 1:]:
+            if line.strip() and not line.startswith((" ", "\t")):
+                break
+            if line.strip():
+                nested.append(line)
+        assert nested, "metadata block has no entries"
+        offenders = [line for line in nested if not re.match(r"^  \S", line)]
+        assert not offenders, (
+            f"metadata entries must be indented exactly two spaces: {offenders}"
+        )
+
+
+class TestInstallCommands:
+    """No hardcoded installer commands in the loaded bundle.
+
+    A bare `pip install` targets whichever interpreter `pip` resolves to, which is not
+    necessarily the one running the code, and drops the pinned version — the failure
+    `scripts/check_version.py` exists to prevent. Naming any single installer also puts
+    the bundle at odds with environments standardized on another one, so the guides say
+    what is needed and let the caller's tooling decide how. `check_version.py` is the one
+    place that prints a command, because it can see the interpreter it is running under.
+    """
+
+    def test_no_installer_commands_in_skill_or_references(self):
+        documents = {"SKILL.md": _read(_SKILL_MD)}
+        for name in sorted(os.listdir(_REFERENCES)):
+            if name.endswith(".md"):
+                documents[f"references/{name}"] = _read(os.path.join(_REFERENCES, name))
+
+        offenders = []
+        for name, text in documents.items():
+            for number, line in enumerate(text.splitlines(), 1):
+                if re.search(r"\b(pip|uv|conda|poetry)\s+(pip\s+)?(install|add)\b", line):
+                    offenders.append(f"{name}:{number}: {line.strip()}")
+        assert not offenders, (
+            "state the package that is needed and point at scripts/check_version.py "
+            "instead of hardcoding an installer:\n" + "\n".join(offenders)
+        )


### PR DESCRIPTION
Review of the vendored copy in [K-Dense-AI/scientific-agent-skills#158](https://github.com/K-Dense-AI/scientific-agent-skills/pull/158) surfaced two things that registry has to patch locally after every sync. Both are fixed here, so the next sync is a file copy with no local layer.

## Frontmatter indentation (blocking downstream CI)

`metadata` was nested four spaces. Valid YAML, and `metadata.version` parses fine with a YAML library — but that registry's validator ([`tests/_contract/structure.py`](https://github.com/K-Dense-AI/scientific-agent-skills/blob/main/tests/_contract/structure.py)) reads frontmatter line by line and matches `^  key:` only, so it reported `metadata.version` as missing and failed the bundle on whitespace. Running their repo-wide contract against a straight copy of 1.8.0 produced exactly one structural failure, this one.

Now two spaces, pinned by `tests/test_structure.py::TestFrontmatter::test_metadata_scalars_are_indented_two_spaces`.

## Installer commands

The guides handed out `pip install --upgrade idc-index` in five Prerequisites blocks, plus `pip install duckdb` / `google-cloud-bigquery` mentions. A bare `pip install` targets whichever interpreter `pip` resolves to and drops the pinned version — the failure `scripts/check_version.py` exists to prevent, and why `USAGE.md` stopped doing it in 1.8.0.

The registry independently rewrites every `pip install` in a vendored skill to `uv pip install` (their commit `4226ca8`), which is the same problem from the other side: any single installer named in the bundle is wrong in some environment. So the guides now name the package that is needed and point at `check_version.py` for `idc-index`, and that script — the one place that can see the interpreter it is running under — prefers `uv` when `uv` is on `PATH`:

```
Install the vetted version with:

    uv pip install --python /path/to/venv/bin/python 'idc-index==0.12.5'
    /path/to/venv/bin/python -m pip install 'idc-index==0.12.5'
```

`--python` matters: a bare `uv pip install` targets the active virtual environment, not necessarily the one that failed to import `idc_index`. Neither form overrides PEP 668 — both refuse on an externally managed interpreter, which is the intended outcome. `tests/test_structure.py` fails on a reintroduced `pip`/`uv`/`conda`/`poetry` install line in `SKILL.md` or `references/`.

## New: `tests/test_check_version.py`

Offline, standard library only, 20 tests: version parsing (numeric ordering, `v` prefixes, pre-release tags), install-command construction, `check_minimum` / `main` exit codes, best-effort network notices, and guards that the script never shells out to an installer and never bypasses PEP 668. Runs with nothing installed.

That last property is deliberate: registries that require a test suite for any skill shipping `scripts/` can run this file as-is instead of writing their own. The cases it duplicated were removed from `tests/test_snippets.py`, which needs `idc-index` installed. `scripts/**` was also missing from the `test-snippets.yml` path filters, so a change to the bundled script did not trigger CI.

## Verification

- `pytest tests/test_structure.py tests/test_check_version.py` — 33 passed, no network, no `idc-index`
- `SKILL.md` is 495 lines (budget 500)
- No `pip`/`uv`/`conda`/`poetry` install command remains in `SKILL.md`, `references/`, `USAGE.md`, or `README.md`
- `scripts/check_version.py` run against a 0.12.3 environment prints both commands and exits 1
- `uv pip install --python <venv> --dry-run 'idc-index==0.12.5'` resolves; against an externally managed interpreter it refuses with the PEP 668 message, as intended

🤖 Generated with [Claude Code](https://claude.com/claude-code)

